### PR TITLE
Remove link to blog post that has gone 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-dupe --allow-redirect --white-list http://hoth.entp.com/2008/11/10/improving-my-git-workflow
+  - awesome_bot README.md --allow-dupe --allow-redirect

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you aren't using any zsh frameworks, or if you're a bash user, do the followi
 * git-outgoing - Michael Markert's [dotfiles](https://github.com/cofi/dotfiles)
 * git-pie-ify - JeeBak Kim's [gist](https://gist.github.com/jeebak/f9088cede18d31f2d3a0)
 * git-plotrepo - Matthew McCullogh's [scripts collection](https://github.com/matthewmccullough/scripts/blob/master/git-plotrepo.rb)
-* git-promote - Trevor's [Improving My git Workflow](http://hoth.entp.com/2008/11/10/improving-my-git-workflow) blog post
+* git-promote - Trevor's Improving My git Workflow blog post (404 now)
 * git-prune-branches - Michael Demmer in [jut-io/git-scripts](https://github.com/jut-io/git-scripts/blob/master/bin/git-prune-branches)
 * git-publish - Michael Markert's [dotfiles](https://github.com/cofi/dotfiles)
 * git-purge-from-history - David Underhill’s blog


### PR DESCRIPTION
Improving my git workflow doesn't look like its ever coming back, so get
rid of the temporary whitelisting

Closes #6