### PR TITLE
Make git-upstream-sync use a configurable remote

### DIFF
--- a/bin/git-upstream-sync
+++ b/bin/git-upstream-sync
@@ -7,11 +7,17 @@
 # Sync to upstream/yourforkname and rebase into your local fork. then push
 # back into yourfork/yourforkname
 #
-# Assumes that your upstream fork's remote is named upstream
+# Assumes that your upstream fork's remote is named upstream unless you
+# set upstream-sync.remote with git config
 
 branch_name=$(git symbolic-ref --short -q HEAD)
+upstream_remote=$(git config --get upstream-sync.remote)
+if [[ $? != 0 ]]; then
+  echo 'Using default remote of upstream'
+  upstream_remote='upstream'
+fi
 
-git fetch upstream && \
-  git rebase upstream/${branch_name} && \
+git fetch ${upstream_remote} && \
+  git rebase ${upstream_remote}/${branch_name} && \
   git push && \
   git fetch -p

--- a/bin/git-upstream-sync
+++ b/bin/git-upstream-sync
@@ -12,12 +12,13 @@
 
 branch_name=$(git symbolic-ref --short -q HEAD)
 upstream_remote=$(git config --get upstream-sync.remote)
+# shellcheck disable=SC2181
 if [[ $? != 0 ]]; then
   echo 'Using default remote of upstream'
   upstream_remote='upstream'
 fi
 
 git fetch ${upstream_remote} && \
-  git rebase ${upstream_remote}/${branch_name} && \
+  git rebase "${upstream_remote}/${branch_name}" && \
   git push && \
   git fetch -p


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

# Description

Make `git-upstream-sync` read the upstream remote with `git config` and default to using
upstream if that is unset.

# Type of changes

- [x] Add/update a helper script
- [ ] A link to an external resource like a blog post

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [x] Scripts are marked executable
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.
