### PR TITLE
added two git commands git age and git maildiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ If you aren't using any zsh frameworks, or if you're a bash user, do the followi
 
 | Script | Original Source | Description |
 | ------ | --------------- | ----------- |
+| `git-age` | Kristoffer Gronlund's [wiki](https://github.com/krig/git-age/wiki) | A git-blame viewer, written using PyGTK.| 
 | `git-attic` | Christian Neukirchen's [blog](http://chneukirchen.org/blog/archive/2013/01/a-grab-bag-of-git-tricks.html) | Displays a list of deleted files in your repo. The output is designed to be copy and pasted: Pass the second field to `git show` to display the file contents, or just select the hash without ^ to see the commit where removal happened. |
 | `git-big-file` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Show files in the repo larger than a threshold size. |
 | `git-change-author` | Michael Demmer in [jut-io/git-scripts](https://github.com/jut-io/git-scripts/blob/master/bin/git-change-author) | Change one author/email in the history to another. |

--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ If you aren't using any zsh frameworks, or if you're a bash user, do the followi
 | `git-incoming-commits` | Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) | Adds a remote for the current repository for the given github username. |
 | `git-incoming` | Michael Markert's [dotfiles](https://github.com/cofi/dotfiles) | Show commits in the tracking branch that are not in the local branch. |
 | `git-ls-object-refs` | Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) | Find references to an object with SHA1 in refs, commits, and trees. All of them. |
-| `git-maildiff` | Sanjeev Kumar's
-[blogpost](http://www.devilsan.com/blog/my-first-git-command-git-ipush-using-python) | A simple git
-command to email diff in color to reviewer/ co-worker. |
+| `git-maildiff` | Sanjeev Kumar's [blogpost](http://www.devilsan.com/blog/my-first-git-command-git-ipush-using-python) | A simple git command to email diff in color to reviewer/ co-worker. |
 | `git-maxpack` | John Wiegley's [git-scripts](https://github.com/jwiegley/git-scripts) | Compress a repo's pack files as much as possible. |
 | `git-move-commits` | Corey Oordt's [git-scripts](https://github.com/coordt/git-scripts/blob/master/git-move-commits) | `git move-commits num-commits correct-branch` moves the last n commits to correct-branch (creating it if necessary). |
 | `git-neck` | Christian Neukirchen's [blog](http://chneukirchen.org/blog/archive/2013/01/a-grab-bag-of-git-tricks.html) | Show commits from the HEAD until the first branching point. Companion script for `git-trail`. |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ If you aren't using any zsh frameworks, or if you're a bash user, do the followi
 | `git-incoming-commits` | Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) | Adds a remote for the current repository for the given github username. |
 | `git-incoming` | Michael Markert's [dotfiles](https://github.com/cofi/dotfiles) | Show commits in the tracking branch that are not in the local branch. |
 | `git-ls-object-refs` | Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) | Find references to an object with SHA1 in refs, commits, and trees. All of them. |
+| `git-maildiff` | Sanjeev Kumar's
+[blogpost](http://www.devilsan.com/blog/my-first-git-command-git-ipush-using-python) | A simple git
+command to email diff in color to reviewer/ co-worker. |
 | `git-maxpack` | John Wiegley's [git-scripts](https://github.com/jwiegley/git-scripts) | Compress a repo's pack files as much as possible. |
 | `git-move-commits` | Corey Oordt's [git-scripts](https://github.com/coordt/git-scripts/blob/master/git-move-commits) | `git move-commits num-commits correct-branch` moves the last n commits to correct-branch (creating it if necessary). |
 | `git-neck` | Christian Neukirchen's [blog](http://chneukirchen.org/blog/archive/2013/01/a-grab-bag-of-git-tricks.html) | Show commits from the HEAD until the first branching point. Companion script for `git-trail`. |

--- a/git-extra-commands.plugin.zsh
+++ b/git-extra-commands.plugin.zsh
@@ -22,6 +22,7 @@ alias gitroot='cd $(git rev-parse --show-toplevel) && echo "$_"'
 #   incoming-commits  (appears to be a dupe of grab)
 #   mark-all-resolved (git: 'conflicts' is not a git command.)
 zstyle ':completion:*:*:git:*' user-commands \
+  age:'A git-blame viewer, written using PyGTK written by Kristoffer Gronlund ' \
   big-file:'List disk size of files in ref' \
   change-author:'Rewrite commits, updating author/email' \
   changes:'List authors/emails with commit count' \
@@ -38,6 +39,7 @@ zstyle ':completion:*:*:git:*' user-commands \
   improved-merge:'Sophisticated git merge with integrated CI check and automatic cleanup upon completion' \
   incoming:'Fetch remote tracking branch, and list incoming commits' \
   ls-object-refs:'Find references to <object> SHA1 in refs, commits, and trees. All of them' \
+  maildiff: 'Simple git command to email diff in color to reviewer/co-worker & optionally attach patch file.' \
   maxpack:'Repack with maximum compression' \
   nuke:'Nukes a branch locally and on the origin remote' \
   object-deflate:'Deflate an loose object file and write to standard output' \


### PR DESCRIPTION
Added two commands to readme:

1. git age
2. git maildiff


# Description

git-age is pyGtk based git blame viewer.
git-maildiff is a simple git command to email the diff in colour to reviewer or coworker.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [ ] Scripts are marked executable
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.
