### PR TITLE
Add git-extend link to External Git Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Here are some helpful aliases for your `~/.gitconfig`
 * [git-crypt](https://www.agwa.name/projects/git-crypt/) - Enables transparent encryption and decryption of files in a git repository. Files which you choose to protect are encrypted when committed, and decrypted when checked out.
 * [git-deploy-s3](https://github.com/bradt/git-deploy-s3) - Keeps your git repo's assets in sync with Amazon S3.
 * [git-diffall](https://github.com/thenigan/git-diffall) - Provides a directory based diff mechanism for git.
+* [git-extend](https://github.com/nickolasburr/git-extend) - Extend Git builtins with command wrappers.
 * [git-fastclone](https://github.com/square/git-fastclone) - Think `git clone --recursive` on steroids. If you're doing repeated checkouts of a given repo on a machine (like a ci box), **git-fastclone** will speed things up considerably.
 * [git-follow](https://github.com/nickolasburr/git-follow) - Follow lifetime changes of a pathspec.
 * [git-flow-completion](https://github.com/bobthecow/git-flow-completion) - Bash, Fish and Zsh completion support for [git-flow](http://github.com/nvie/gitflow)


### PR DESCRIPTION
# Description

Add [git-extend](https://github.com/nickolasburr/git-extend) link to External Git Utilities section.

# Type of changes

- [ ] A helper script
- [x] A link to an external resource like a blog post

# Checklist:

- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [ ] Scripts are marked executable
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.