### PR TITLE
Update cut branch

### DIFF
--- a/bin/git-cut-branch
+++ b/bin/git-cut-branch
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # https://github.com/rtomayko/dotfiles
 #
@@ -37,7 +37,7 @@ sha=$(git rev-parse HEAD)
 die "you're not on a branch"
 
 # just the branch name please
-current=$(echo "$ref" |sed 's@^refs/heads/@@')
+current=$(echo "$ref" | sed 's@^refs/heads/@@')
 [ -n "$current" ] ||
 die "you're in a weird place; get on a local branch"
 
@@ -47,11 +47,12 @@ merge=$(git config --get "branch.$current.merge" | sed 's@refs/heads/@@')
 
 # build up a sane <remote>/<branch> name
 # shellcheck disable=SC2166
-if [ -n "$remote" -a -n "$merge" ]
-then tracking="$remote/$merge"
-elif [ -n "$merge" ]
-then tracking="$merge"
-else die "$current is not tracking anything"
+if [ -n "$remote" -a -n "$merge" ]; then
+  tracking="$remote/$merge"
+elif [ -n "$merge" ]; then
+  tracking="$merge"
+else
+  die "$current is not tracking anything"
 fi
 
 # make sure there's no changes before we reset hard

--- a/bin/git-cut-branch
+++ b/bin/git-cut-branch
@@ -65,7 +65,7 @@ fi
 git branch "$branch"
 git reset -q --hard "$tracking"
 git checkout -q "$branch"
-git branch --set-upstream "$branch" "$tracking"
+git branch --set-upstream-to "$branch" "$tracking"
 git reset -q --hard "$sha"
 # shellcheck disable=SC2086,SC2046
 echo "[$(shortsha "$sha")...$(shortsha $(git rev-parse $tracking))] $current"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`git branch` no longer uses `--set-upstream`, so updated `git-cut-branch` to use `--set-upstream-to` instead.

# Type of changes

- [x] A helper script
- [ ] A link to an external resource like a blog post

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [ ] Scripts are marked executable
- [ ] I have added a credit line to README.md for the script
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.