### PR TITLE
Add link to git-complete-urls ZSH plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Here are some helpful aliases for your `~/.gitconfig`
 * [git-branches](https://github.com/shurcooL/git-branches) - Prints the commit behind/ahead counts for branches.
 * [git-bump](https://github.com/arrdem/git-bump) - Hook scripts to automatically bump the version file in a repository
 * [git-chart](https://github.com/flashcode/gitchart) - A python script that builds charts from a git repository
+* [git-complete-urls](https://github.com/rapgenic/zsh-git-complete-urls) - ZSH plugin to enhance git completion to include in the remotes completion (e.g. from `git clone`) any URL in the clipboard.
 * [git-cop](https://github.com/bkuhlmann/git-cop) - Enforces Git rebase workflow with consistent Git commits for a clean and easy to read/debug project history.
 * [git-crypt](https://www.agwa.name/projects/git-crypt/) - Enables transparent encryption and decryption of files in a git repository. Files which you choose to protect are encrypted when committed, and decrypted when checked out.
 * [git-deploy-s3](https://github.com/bradt/git-deploy-s3) - Keeps your git repo's assets in sync with Amazon S3.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add link to [git-complete-urls](https://github.com/rapgenic/zsh-git-complete-urls), a ZSH plugin to enhance git completion to include in the remotes completion (e.g. from `git clone`) any URL in the clipboard.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A helper script
- [x] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [ ] Scripts are marked executable
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
