### PR TITLE
Fix submodule-rm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-show-overwritten` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Aggregates `git blame` information about the original owners of lines changed or removed in the '<base>...<head>' diff. |
 | `git-sp` | A. Schwarz's [git-sp](https://github.com/Schwarzy1/git-sp) | "Simple push", single short command to commit, and push. Use -a flag to add all files to commit. |
 | `git-switch` | Andrew Steele's [dotfiles](https://github.com/Andrew565/dotfiles) | Make it easier to switch to a branch by a substring of its name. More useful if you are good about deleting branches which have been merged upstream and if your branch names include unique identifiers like ticket/issue numbers. |
-| `git-submodule-rm` | Greg V's [dotfiles](https://github.com/myfreeweb/dotfiles) | Allows you to remove a submodule easily with `git submodule-rm path/to/submodule`. |
+| `git-submodule-rm` | Greg V's [dotfiles](https://github.com/myfreeweb/dotfiles) & [Pascal Sommer](https://github.com/pascal-so/) | Allows you to remove a submodule easily with `git submodule-rm path/to/submodule`. |
 | `git-tag-and-sign` | ? | Create and sign a new tag |
 | `git-thanks` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | List the contributors to a repository in descending commit order, even if their contribution has been completely replaced. |
 | `git-track` | Zach Holman's [dotfiles](https://github.com/holman/dotfiles) | Sets up your branch to track a remote branch. Assumes you mean *origin/localbranchname*. |

--- a/bin/git-submodule-rm
+++ b/bin/git-submodule-rm
@@ -1,20 +1,58 @@
-#!/usr/bin/env zsh
-# This came from Greg V's dotfiles:
-#      https://github.com/myfreeweb/dotfiles
-# Feel free to steal it, but attribution is nice
+#!/usr/bin/env bash
 #
-# thanks: http://stackoverflow.com/a/7646931/239140
+# Author: Pascal Sommer <github.com/pascal-so>
+#
+# This is a heavily modified version of the script from Greg V's dotfiles:
+#     https://github.com/myfreeweb/dotfiles
+#
+# The reason for the heavy modification is that the original script left
+# traces of the submodule behind, specifically in `.git/modules`. This
+# udpated version also improves error handling.
+#
+# Some useful resources:
+#     https://stackoverflow.com/a/7646931
+#     https://stackoverflow.com/a/16162000
 
-if [[ -e $(pwd)/.gitmodules ]]; then
-  if [[ $# -eq 0 ]]; then
-    echo 'Usage: git submodule-rm <path ...>'
-  else
-    for submodulepath in $@; do
-      git config -f .git/config --remove-section "submodule.$submodulepath"
-      git config -f .gitmodules --remove-section "submodule.$submodulepath"
-      git rm --cached "$submodulepath"
-    done
-  fi
-else
-  echo 'Run this from the root of your repo (which must have .gitmodules)'
+set -eu
+
+if [[ $# -eq 0 ]]; then
+  echo 'Usage: git submodule-rm <path ...>' >&2
+  exit 2
 fi
+
+if [[ ! -f .gitmodules ]]; then
+  echo 'Run this from the root of your repo which must have a .gitmodules file.' >&2
+  exit 1
+fi
+
+if [[ ! -w .gitmodules ]]; then
+  echo '.gitmodules file is not writable for the current user.' >&2
+  exit 1
+fi
+
+for path in "$@"; do
+  submodule_path="${path%/}"
+
+  if [[ -z "$(git config --file=.gitmodules "submodule.${submodule_path}.url")" ]]; then
+    echo "Submodule '$submodule_path' not found." >&2
+    continue
+  fi
+
+  if [[ ! -w "$submodule_path" ]]; then
+    echo "Submodule path '$submodule_path' is not writable." >&2
+    continue
+  fi
+
+  # If any of the following commands fail it's probably because the repo
+  # was already in a corrupted state and we can't do anything to handle
+  # that anyway so we just let the entire script crash.
+
+  git submodule --quiet deinit --force "$submodule_path"
+  rmdir "$submodule_path"
+  git rm --cached -rfq "$submodule_path"
+
+  git config -f .gitmodules --remove-section "submodule.$submodule_path"
+  rm -rf ".git/modules/$submodule_path"
+
+  git add .gitmodules
+done


### PR DESCRIPTION
# Description

The existing version of `submodule-rm` didn't remove the data in `.git/modules`. It also failed when running in an unclean git directory.

This PR replaces most of the script, but I left the credit to Greg V in the script because it still contains some of the original work.

Note that this PR also changes the interpreter from zsh to bash.

# Type of changes

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [x] Scripts are marked executable
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
