### PR TITLE
Fix filtering out checked out branches

### DIFF
--- a/bin/git-delete-local-merged
+++ b/bin/git-delete-local-merged
@@ -6,4 +6,4 @@
 #   https://plus.google.com/115587336092124934674/posts/dXsagsvLakJ
 
 # shellcheck disable=SC2046,SC2063
-exec git branch -d $(git branch --merged | grep -v '^*' | tr -d '\n')
+exec git branch -d $(git branch --merged | grep -v '^[*+]' | tr -d '\n')

--- a/bin/git-delete-merged-branches
+++ b/bin/git-delete-merged-branches
@@ -15,4 +15,4 @@ if [[ "${currentBranch}" != "${mergedInto}" ]]; then
   exit 1
 fi
 
-git branch --merged "${mergedInto}" | grep -v "\* ${mergedInto}" | xargs -n 1 git branch -d
+git branch --merged "${mergedInto}" | grep -v "^[*+]" | xargs -n 1 git branch -d


### PR DESCRIPTION
This fixes commands `delete-local-merged` and `delete-merged-branches` in case of having several working trees with different branches checked out.

# Description

`git branch` prepends checked out branches not only with `*`, but also with `+` if they're checked out in another working trees:

```
$ git branch
+ feature/something-something
* master
  refactoring/something-else
```

Using `delete-local-merged` produces errors in such case:

```
$ git delete-local-merged
error: branch '+' not found.
error: Cannot delete branch 'feature/something-something' checked out at '/path-to-the-repo'
```

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
