### PR TITLE
No need for both scripts

### DIFF
--- a/bin/git-delete-local-merged
+++ b/bin/git-delete-local-merged
@@ -1,9 +1,1 @@
-#!/usr/bin/env bash
-#
-# Delete all local branches that have been merged into HEAD. Stolen from
-# our favorite @tekkub:
-#
-#   https://plus.google.com/115587336092124934674/posts/dXsagsvLakJ
-
-# shellcheck disable=SC2046,SC2063
-exec git branch -d $(git branch --merged | grep -v '^[*+]' | tr -d '\n')
+git-delete-merged-branches


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`git-delete-merged-branches` and `git-delete-local-merged` both do the same thing, but `git-delete-merged-branches` works better. Get rid of `git-delete-local-merged`, but make it a symlink to `git-delete-merged-branches` so we don't break people's workflows.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] A helper script
- [ ] A link to an external resource like a blog post or video
- [x] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
