### PR TITLE
git-current-branch was redundant, replace with symlink

### DIFF
--- a/bin/git-current-branch
+++ b/bin/git-current-branch
@@ -1,7 +1,1 @@
-#!/usr/bin/env bash
-#
-# Print the name of the current branch. Useful for automation scripts.
-#
-# Copyright 2018, Joe Block <jpb@unixorn.net>
-
-exec git rev-parse --abbrev-ref HEAD
+git-branch-name


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description
`git-current-branch` is basically the same as `git-branch-name`, but without trimming the whitespace.

Make it a symlink to `git-branch-name` so removing it doesn't break people's scripts.

Closes #122

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [x] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
