### PR TITLE
Make `git-edit-conflicts` specific to conflicts

### DIFF
--- a/bin/git-edit-conflicts
+++ b/bin/git-edit-conflicts
@@ -1,13 +1,12 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-if ENV.has_key?('VISUAL')
-  edit=ENV['VISUAL']
-elsif ENV.has_key?('EDITOR')
-  edit=ENV['EDITOR']
+if [ -n "$VISUAL" ]; then
+    edit=$VISUAL
+elif  [ -n "$EDITOR" ]; then
+    edit=$EDITOR
 else
-  puts "$VISUAL and $EDITOR are both unset, aborting"
-  exit 1
-end
+    echo "\$VISUAL and \$EDITOR are both unset, aborting"
+    exit 1
+fi
 
-conflicts = `git diff --name-only | uniq`.gsub(/\n/,' ')
-exec("#{edit} #{conflicts}")
+git conflicts | xargs "$edit"


### PR DESCRIPTION
The command roughly boiled down to `git diff --name-only | uniq`, which isn't specific to just conflicted files.  It works if run when first entering a conflicted state, but if you unstage any changes it'll cause some issues.  More to the point, if run when *not* in a conflicted state, it would just open any unstaged changes, since it's just looking for unstaged changes.  We already have a good script for listing files in a conflict state ([`git-conflicts`](https://github.com/unixorn/git-extra-commands/blob/cc3d4f2d3a8718bfa7bf902ae296f31ebca50a5c/bin/git-conflicts), which runs `git ls-files -u | awk '{print $4}' | sort -u`), which is already reused in [`git-mark-all-resolved`](https://github.com/unixorn/git-extra-commands/blob/cc3d4f2d3a8718bfa7bf902ae296f31ebca50a5c/bin/git-mark-all-resolved).  This mirrors that behavior to be specific to conflict state, switching the script from ruby to bash.

----

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [X] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)\
- [X] Scripts are marked executable
- [X] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [X] I have confirmed that the link(s) in my PR are valid.
- [X] I have read the **CONTRIBUTING** document.

# License Acceptance

- [X] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
