### PR TITLE
Add zsh plugin link to replace the stock omz one

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ If you aren't using any ZSH frameworks, or if you're using `bash`, `fish` or ano
 * [branch-manager](https://github.com/elstgav/branch-manager) - ZSH plugin for branch management
 * [commit-helper](https://github.com/andre-filho/commit-helper) - A python script that helps you write commits following commit conventions.
 * [diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) - Better looking git diffs
+* [git zsh plugin](https://github.com/davidde/git) - A replacement for the stock oh-my-zsh git plugin. Provides quite a few useful aliases and functions that are more consistent in their naming that the relatively unintuitive ones in the stock plugin.
 * [git-aliases.zsh](https://github.com/peterhurford/git-aliases.zsh) - Peter Hurford's git plugin which you may prefer to the git plugin from oh-my-zsh.
 * [git-also](https://github.com/anvaka/git-also) - Shows what files are most often committed with a given file in the repository.
 * [git-amend](https://github.com/colinodell/git-amend-old) - Bash script to amend older commits with staged changes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add zsh plugin link to replace the stock omz one

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [x] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
