### PR TITLE
Not all repos have master as their default branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-recently-checkedout-branches` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Shows timestamp and name of recently checked-out branches in reverse chronological order. |
 | `git-ref-recent` | [Y combinator article](https://news.ycombinator.com/item?id=22796640) | Shows the date, branch name, commit hash, and commit subject of branches, from most recently modified to oldest branches. |
 | `git-rel` | Ryan Tomayko's [dotfiles](http://github.com/rtomayko/dotfiles) | Shows the relationship between the current branch and *ref*>*. With no *ref*, the current branch's remote tracking branch is used. |
+| `git-remote-default-branch` | Mine | Shows the default branch for a specified remote, defaults to origin when no remote is specified. |
 | `git-related` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Show other files that often get changed in commits that touch `<file>`. |
 | `git-rename-branches` | Rodrigo Silva (MestreLion) <linux@rodrigosilva.com> | Rename multiple branches that start with a given name. |
 | `git-reset-with-fire` | Joe Block <jpb@unixorn.net> | Hard reset the working directory, then zap any files not known to git. |

--- a/bin/git-prune-branches
+++ b/bin/git-prune-branches
@@ -14,7 +14,13 @@
 # License: MIT
 # Original source: https://github.com/jut-io/git-scripts/blob/master/bin/git-prune-branches
 
-merged=$(git branch --no-color --merged master | grep -v master | sed 's/\*/ /')
+PRIMARY_BRANCH=$(git remote show origin | awk '/HEAD branch/ {print $3}')
+if [[ -z "$PRIMARY_BRANCH" ]]; then
+  echo "Could not determine primary branch"
+  exit 13
+fi
+
+merged=$(git branch --no-color --merged "$PRIMARY_BRANCH" | grep -v "$PRIMARY_BRANCH" | sed 's/\*/ /')
 
 if [ ! -z "$merged" ] ; then
   echo "Deleting the following merged branches:"

--- a/bin/git-remote-default-branch
+++ b/bin/git-remote-default-branch
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Find the default branch for a given git remote, or origin if unspecified
+#
+# Copyright 2020, Joe Block <jpb@unixorn.net>
+
+set -o pipefail
+
+echo $#
+
+if [[ $# -eq 0 ]]; then
+  REMOTENAME='origin'
+fi
+if [[ $# -gt 0 ]];then
+  REMOTENAME="$1"
+fi
+
+git remote show "${REMOTENAME}" | awk '/HEAD branch/ {print $3}'
+exit $?


### PR DESCRIPTION
# Description

Many repositories have switched from using 'master' to a less potentially offensive name like 'main' for their primary branch.

* Update `git-prune-branches` to not assume the default branch is named master.
* Add `git-remote-default-branch` to make it easy to find the default branch name.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [x] Script cleanups/updates
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
