### PR TITLE
Add another method for finding a remote's default branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,15 @@ If you aren't using any ZSH frameworks, or if you're using `bash`, `fish` or ano
 
 Many repositories are switching away from using **master** as the default branch name. You can do `git config --global alias.co-default '!'"git checkout \$(git branch -r | awk -F/ '/HEAD/ {print \$NF}')"` to add a co-default alias that will determine what the repository's default branch is for you.
 
+Alternatively, add the following aliases from a [tweet by @jnesselr](https://twitter.com/jnesselr/status/1334586152691625985) to your `.gitconfig` file:
+
+```
+cdef = "!git checkout $(git originhead)"
+originhead = "!git remote show origin | grep 'HEAD branch' | cut -d ' ' -f5"
+```
+
+This queries the remote to get the current up to date default branch, so it will work even if the remote's default branch changes after you did your initial checkout.
+
 ### Have git cope with typos
 
 Do `git config --global help.autocorrect 1`


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

This one's from a [tweet by @jnesselr](https://twitter.com/jnesselr/status/1334586152691625985).

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] A helper script
- [x] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [ ] Scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [ ] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
