### PR TITLE
Add fzf helper scripts and article links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-force-mtimes` | John Wiegley's [git-scripts](https://github.com/jwiegley/git-scripts) | Sets mtimes of all files in the reprository their last change date based on git's log. Useful to avoid too new dates after a checkout confusing `make` or `rake`. |
 | `git-forest` | Jan Engelhardt | Prints a text-based tree visualisation of your repository. Requires [Git.pm](https://metacpan.org/release/Git) |
 | `git-functionlog` | Joe Block <jpb@unixorn.net> | Allows you to get a log of a particular function, not a file |
+| `git-fzf-add` | [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) | Use [fzf](https://github.com/junegunn/fzf) to select files to add to `git` |
 | `git-git` | Joe Block <jpb@unixorn.net> | Typing `git git foo` will make git do a `git foo` instead of complaining. |
 | `git-github-open` | ? | Open GitHub file/blob page for FILE on LINE. |
 | `git-gitlab-mr` | Noel Cower's [gist](https://gist.github.com/nilium/ac808ee3729cdce01ec0f3c0a499f099) | Open a merge request on GitLab |

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-incoming` | Michael Markert's [dotfiles](https://github.com/cofi/dotfiles) | Show commits in the tracking branch that are not in the local branch. |
 | `git-lines` | [Neil Killeen](https://github.com/kiLLeen) <nkilleen@castlighthealth.com> | Gives you a list of author names with the number of lines last updated by that user in files in the current directory tree with the extension specified. |
 | `git-ls-object-refs` | Ryan Tomayko's [dotfiles](https://github.com/rtomayko/dotfiles) | Find references to an object with SHA1 in refs, commits, and trees. All of them. |
-| `git-maildiff` | Sanjeev Kumar's [blogpost](http://www.devilsan.com/blog/my-first-git-command-git-ipush-using-python) | A simple git command to email diff in color to reviewer/ co-worker. |
-| `git-maxpack` | John Wiegley's [git-scripts](https://github.com/jwiegley/git-scripts) | Compress a repo's pack files as much as possible. |
+| `git-maildiff` | Sanjeev Kumar's blogpost | A simple `git` command to email diff in color to reviewer/ co-worker. |
+| `git-maxpack` | John Wiegley's [git-scripts](https://github.com/jwiegley/git-scripts) | Compress a repository's pack files as much as possible. |
 | `git-move-commits` | Corey Oordt's [git-scripts](https://github.com/coordt/git-scripts/blob/master/git-move-commits) | `git move-commits num-commits correct-branch` moves the last n commits to correct-branch (creating it if necessary). |
 | `git-neck` | Leah Neukirchen's [blog](https://leahneukirchen.org/blog/archive/2013/01/a-grab-bag-of-git-tricks.html) | Show commits from the HEAD until the first branching point. Companion script for `git-trail`. |
 | `git-nuke` | Zach Holman's [dotfiles](https://github.com/holman/dotfiles) | Nukes a branch locally and on the origin remote. |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-forest` | Jan Engelhardt | Prints a text-based tree visualisation of your repository. Requires [Git.pm](https://metacpan.org/release/Git) |
 | `git-functionlog` | Joe Block <jpb@unixorn.net> | Allows you to get a log of a particular function, not a file |
 | `git-fzf-add` | [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) | Use [fzf](https://github.com/junegunn/fzf) to select files to add to `git` |
+| `git-fzf-log-browser` | [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) | Use [fzf](https://github.com/junegunn/fzf) to browse the repository's `git` log |
+| `git-fzf-pickaxe-browser` | [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) | Use [fzf](https://github.com/junegunn/fzf) to display a Git log list that has been filtered with [pickaxe](http://www.philandstuff.com/2014/02/09/git-pickaxe.html) for a search term. |
+| `git-fzf-reflog-browser` | [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) | Use [fzf](https://github.com/junegunn/fzf) to browse the repository's `git` reflog list that can be filtered by entering a fuzzy term at the prompt. Navigation up and down the hash list will preview the changes of each hash. |
 | `git-git` | Joe Block <jpb@unixorn.net> | Typing `git git foo` will make git do a `git foo` instead of complaining. |
 | `git-github-open` | ? | Open GitHub file/blob page for FILE on LINE. |
 | `git-gitlab-mr` | Noel Cower's [gist](https://gist.github.com/nilium/ac808ee3729cdce01ec0f3c0a499f099) | Open a merge request on GitLab |

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ If you aren't using any ZSH frameworks, or if you're using `bash`, `fish` or ano
 
 * [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) - Great article about using [fzf](https://github.com/junegunn/fzf) with some `git` helper scripts.
 
+* [The Git Pickaxe](http://www.philandstuff.com/2014/02/09/git-pickaxe.html) - Explains how you can use the `git` pickaxe to search easily for strings in commit messages - write good commit messages and it'll be easier to find the commits that actually implement changes.
+
 ### External Git Utilities
 
 * [bfg repo-cleaner](https://rtyley.github.io/bfg-repo-cleaner/) - Removes large or troublesome blobs like `git filter-branch` does, but faster.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ If you aren't using any ZSH frameworks, or if you're using `bash`, `fish` or ano
 
 * [A Thorough Introduction to Git's Interactive Patch Mode](https://dev.to/krnsk0/a-thorough-introduction-to-git-s-interactive-patch-mode-4bl6) - An introduction on how to stage just parts of your changes to a commit.
 
+* [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) - Great article about using [fzf](https://github.com/junegunn/fzf) with some `git` helper scripts.
+
 ### External Git Utilities
 
 * [bfg repo-cleaner](https://rtyley.github.io/bfg-repo-cleaner/) - Removes large or troublesome blobs like `git filter-branch` does, but faster.

--- a/bin/git-fzf-add
+++ b/bin/git-fzf-add
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+if has bat; then
+  git-fzf-add() {
+    local selections=$(
+      git status --porcelain | \
+      fzf --ansi \
+        --preview 'if (git ls-files --error-unmatch {2} &>/dev/null); then
+                    git diff --color=always {2}
+                  else
+                      bat --color=always --line-range :500 {2}
+                  fi'
+      )
+    if [[ -n $selections ]]; then
+        git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
+    fi
+  }
+else
+  # Use head since bat is missing
+  git-fzf-add() {
+    local selections=$(
+      git status --porcelain | \
+      fzf --ansi \
+        --preview 'if (git ls-files --error-unmatch {2} &>/dev/null); then
+                    git diff --color=always {2}
+                  else
+                      head -100 {2}
+                  fi'
+      )
+    if [[ -n $selections ]]; then
+        git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
+    fi
+  }
+fi
+# shellcheck disable=SC2068
+git-fzf-add $@

--- a/bin/git-fzf-add
+++ b/bin/git-fzf-add
@@ -14,7 +14,7 @@ fail() {
 
 if has bat; then
   git-fzf-add() {
-    local selections=$(
+    selections=$(
       git status --porcelain | \
       fzf --ansi \
         --preview 'if (git ls-files --error-unmatch {2} &>/dev/null); then
@@ -23,14 +23,15 @@ if has bat; then
                       bat --color=always --line-range :500 {2}
                   fi'
       )
-    if [[ -n $selections ]]; then
-        git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
+    if [[ -n "$selections" ]]; then
+      # shellcheck disable=SC2046
+      git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
     fi
   }
 else
   # Use head since bat is missing
   git-fzf-add() {
-    local selections=$(
+    selections=$(
       git status --porcelain | \
       fzf --ansi \
         --preview 'if (git ls-files --error-unmatch {2} &>/dev/null); then
@@ -39,8 +40,9 @@ else
                       head -100 {2}
                   fi'
       )
-    if [[ -n $selections ]]; then
-        git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
+    if [[ -n "$selections" ]]; then
+      # shellcheck disable=SC2046
+      git add --verbose $(echo "$selections" | cut -c 4- | tr '\n' ' ')
     fi
   }
 fi

--- a/bin/git-fzf-add
+++ b/bin/git-fzf-add
@@ -46,5 +46,10 @@ else
     fi
   }
 fi
+
+if ! has fzf; then
+  fail "You need fzf (https://github.com/junegunn/fzf) to use this script. "
+fi
+
 # shellcheck disable=SC2068
 git-fzf-add $@

--- a/bin/git-fzf-log-browser
+++ b/bin/git-fzf-log-browser
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+git-fzf-log-browser() {
+  selections=$(
+    git log --graph --format="%C(yellow)%h%C(red)%d%C(reset) - %C(bold green)(%ar)%C(reset) %s %C(blue)<%an>%C(reset)" --color=always "$@" |
+      fzf --ansi --no-sort --no-height \
+          --preview "echo {} | grep -o '[a-f0-9]\{7\}' | head -1 |
+                      xargs -I@ sh -c 'git show --color=always @'"
+    )
+  if [[ -n "$selections" ]]; then
+    commits=$(echo "$selections" | sed 's/^[* |]*//' | cut -d' ' -f1 | tr '\n' ' ')
+    # shellcheck disable=SC2086
+    git show $commits
+  fi
+}
+
+# shellcheck disable=SC2068
+git-fzf-log-browser $@

--- a/bin/git-fzf-log-browser
+++ b/bin/git-fzf-log-browser
@@ -26,5 +26,9 @@ git-fzf-log-browser() {
   fi
 }
 
+if ! has fzf; then
+  fail "You need fzf (https://github.com/junegunn/fzf) to use this script. "
+fi
+
 # shellcheck disable=SC2068
 git-fzf-log-browser $@

--- a/bin/git-fzf-pickaxe-browser
+++ b/bin/git-fzf-pickaxe-browser
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+git-fzf-log-pickaxe() {
+  if [[ $# == 0 ]]; then
+    echo 'Error: search term was not provided.'
+    return
+  fi
+  selections=$(
+    git log --oneline --color=always -S "$@" |
+      fzf --ansi --no-sort --no-height \
+          --preview "git show --color=always {1}"
+    )
+  if [[ -n $selections ]]; then
+    commits=$(echo "$selections" | cut -d' ' -f1 | tr '\n' ' ')
+    git show $commits
+  fi
+ }
+
+# shellcheck disable=SC2068
+git-fzf-log-pickaxe $@

--- a/bin/git-fzf-pickaxe-browser
+++ b/bin/git-fzf-pickaxe-browser
@@ -29,5 +29,9 @@ git-fzf-log-pickaxe() {
   fi
  }
 
+if ! has fzf; then
+  fail "You need fzf (https://github.com/junegunn/fzf) to use this script. "
+fi
+
 # shellcheck disable=SC2068
 git-fzf-log-pickaxe $@

--- a/bin/git-fzf-pickaxe-browser
+++ b/bin/git-fzf-pickaxe-browser
@@ -22,7 +22,8 @@ git-fzf-log-pickaxe() {
       fzf --ansi --no-sort --no-height \
           --preview "git show --color=always {1}"
     )
-  if [[ -n $selections ]]; then
+  # shellcheck disable=SC2086
+  if [[ -n "$selections" ]]; then
     commits=$(echo "$selections" | cut -d' ' -f1 | tr '\n' ' ')
     git show $commits
   fi

--- a/bin/git-fzf-reflog-browser
+++ b/bin/git-fzf-reflog-browser
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Original source: https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html
+
+set -o pipefail
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+fail() {
+  printf '%s\n' "$1" >&2  ## Send message to stderr. Exclude >&2 if you don't want it that way.
+  exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+git-fzf-reflog-browser() {
+  selection=$(
+    git reflog --color=always "$@" |
+      fzf --no-multi --ansi --no-sort --no-height \
+          --preview "git show --color=always {1}"
+    )
+  if [[ -n "$selection" ]]; then
+    # shellcheck disable=SC2086
+    git show "$(echo $selection | cut -d' ' -f1)"
+  fi
+}
+# shellcheck disable=SC2068
+git-fzf-reflog-browser $@

--- a/bin/git-fzf-reflog-browser
+++ b/bin/git-fzf-reflog-browser
@@ -23,5 +23,10 @@ git-fzf-reflog-browser() {
     git show "$(echo $selection | cut -d' ' -f1)"
   fi
 }
+
+if ! has fzf; then
+  fail "You need fzf (https://github.com/junegunn/fzf) to use this script. "
+fi
+
 # shellcheck disable=SC2068
 git-fzf-reflog-browser $@


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Add links to [Fuzzy Finding in Bash with fzf](https://bluz71.github.io/2018/11/26/fuzzy-finding-in-bash-with-fzf.html) and [The Git Pickaxe](http://www.philandstuff.com/2014/02/09/git-pickaxe.html) articles
- Add `git-fzf-add`, `git-fzf-log-browser`, `git-fzf-pickaxe-browser` and `git-fzf-reflog-browser` helper scripts.



# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] A helper script
- [x] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [ ] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
