### PR TITLE
Forgot to add the actual git-children-of script

### DIFF
--- a/bin/git-children-of
+++ b/bin/git-children-of
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Original source: https://github.com/jwiegley/git-scripts/blob/master/git-children-of
+
+commit=$1
+branch=$2
+
+[ -z "$branch" ] && branch=HEAD
+
+git rev-list --children "$branch" --not "$commit"^@ \
+  awk "/^$commit/ { print \$2 }"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add missing `git-children-of` script

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] A helper script
- [ ] A link to an external resource like a blog post or video
- [ ] Text cleanups/updates

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an ok exception)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to README.md for the script
- [x] If there was no author credit in a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] I have read the **CONTRIBUTING** document.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
