### PR TITLE
Add Mislav's `git-where-pr` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-what-the-hell-just-happened` | Gary Bernhardt's [dotfiles](https://github.com/garybernhardt/dotfiles/blob/master/bin/git-what-the-hell-just-happened) | Show what just happened. |
 | `git-when-merged` | Michael Haggerty [git-when-merged](https://github.com/mhagger/git-when-merged) | Find when a commit was merged into one or more branches. |
 | `git-where` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Shows where a particular commit falls between releases. |
+| `git-where-pr` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Opens the Pull Request on GitHub where a specified commit originated |
 | `git-whoami` | Peter Eisentraut | Shows what username & email you have configured for the repository you're in |
 | `git-winner` | Garry Dolley [https://github.com/up_the_irons/git-winner](https://github.com/up_the_irons/git-winner) | Shows what authors have made the most commits, both by number of commits and by number of lines changed. |
 | `git-wordiness` | Noel Cower | Shows how wordy people's commit messages are. Useful for shaming the folks who commit atrocities like `git commit -m fixup` |

--- a/bin/git-where-pr
+++ b/bin/git-where-pr
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Usage: git where-pr [--print] <ref>
+#
+# Opens the Pull Request on GitHub where the commit originated.
+# https://github.com/mislav/dotfiles/blob/master/bin/git-where-pr
+set -e
+
+mode=open
+
+case "$1" in
+-h | --help )
+  sed -ne '/^#/!q;s/.\{1,2\}//;1d;p' < "$0"
+  exit 0
+  ;;
+--print )
+  mode=echo
+  shift 1
+  ;;
+esac
+
+ref="$1"
+if [ -z "$ref" ]; then
+  "$0" --help >&2
+  exit 1
+fi
+
+pull_id="$(git log --merges --ancestry-path --oneline "${ref}.." | awk '
+  /Merge pull request #/ { sub("#", "", $5); print $5 }
+' | tail -1)"
+
+if [ -n "$pull_id" ]; then
+  url="$(git remote -v | awk '
+    /^origin\t/ { print $2 }
+  ' | head -1 | sed -E 's!(git@github\.com:|git://github\.com/)!https://github.com/!')"
+  url="${url%.git}"
+  $mode "${url}/pull/${pull_id}"
+else
+  echo "Could not find pull request" >&2
+  exit 1
+fi


### PR DESCRIPTION
# Description

`git-where-pr` opens the Pull Request on GitHub where a commit originated

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/update a helper script
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
