### PR TITLE
Add `checkout-default` alias info

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Here are some helpful aliases for your `~/.gitconfig`
 | alias | Description |
 | ----- | ----------- |
 | `ahead-of-master = log --oneline origin/master..HEAD` | Show commits that haven't made it to master yet. |
+| `checkout-default = !git checkout $(git branch -r | awk -F/ '/HEAD/ {print $NF}')` | Not all repos have `master` as their default branch, and it's a pain trying to remember what each repo uses. `git checkout-default` will figure it out and switch to the default branch for you. |
 | `fetch-pull-requests = fetch origin '+refs/pull/*/head:refs/remotes/origin/pull/*'` | Fetch pull requests from GitHub so you can `git checkout pull/123` and test them locally. |
 | `roots = log --all --oneline --decorate --max-parents=0` | Show the root commits. |
 | `unpushed = log @{u}..` | Show which commits have not been pushed to the tracking branch and are safe to amend/rebase. |


### PR DESCRIPTION
# Description

Not all repos use `master` as the default branch any more, so add an alias to `.gitconfig` to find the current repo's default branch and switch to it.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/update a helper script or alias
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
