### PR TITLE
Add missing `has` function to `git-fzf-{pickaxe,reflog}-browser`

### DIFF
--- a/bin/git-fzf-pickaxe-browser
+++ b/bin/git-fzf-pickaxe-browser
@@ -12,6 +12,10 @@ fail() {
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
 }
 
+function has() {
+  which "$@" > /dev/null 2>&1
+}
+
 git-fzf-log-pickaxe() {
   if [[ $# == 0 ]]; then
     echo 'Error: search term was not provided.'

--- a/bin/git-fzf-reflog-browser
+++ b/bin/git-fzf-reflog-browser
@@ -12,6 +12,10 @@ fail() {
   exit "${2-1}"  ## Return a code specified by $2 or 1 by default.
 }
 
+function has() {
+  which "$@" > /dev/null 2>&1
+}
+
 git-fzf-reflog-browser() {
   selection=$(
     git reflog --color=always "$@" |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Two additional `git-fzf-*` scripts were missing the `has` function. (See #210). 

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [X] Add/update a helper script or `git` alias
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [X] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [X] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
