### PR TITLE
bugfix: git-branch-rebaser support any default branch

### DIFF
--- a/bin/git-branch-rebaser
+++ b/bin/git-branch-rebaser
@@ -8,4 +8,4 @@
 set -o pipefail
 
 # shellcheck disable=SC2046
-exec git rebase -i $(git rev-parse $(git log master..$(git rev-parse --abbrev-ref HEAD) --oneline | tail -1 | awk '{ print $1 }')^)
+exec git rebase -i $(git rev-parse $(git log $(git origin-head)..$(git rev-parse --abbrev-ref HEAD) --oneline | tail -1 | awk '{ print $1 }')^)


### PR DESCRIPTION
# Description

The script currently supports only master. Other commands were updated to support multiple default branches, update this one the same.


# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/update a helper script or `git` alias
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.

Signed-off-by: Tomer Arbel Eliyahu <tomer.b.eliyahu@intel.com>