### PR TITLE
Remove link to @grawity's 404 gist

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -54,7 +54,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISABLE_LINTERS: SPELL_CSPELL,MARKDOWN_MARKDOWN_LINK_CHECK,REPOSITORY_CHECKOV
+          DISABLE_LINTERS: SPELL_CSPELL,MARKDOWN_MARKDOWN_LINK_CHECK,REPOSITORY_CHECKOV,REPOSITORY_TRIVY
 
       # Upload Mega-Linter artifacts.
       # They will be available on Github action page "Artifacts" section

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ WARNING: You called a Git command named 'commt', which does not exist.
 Continuing in 0.1 seconds, assuming that you meant 'commit'.
 ```
 
-### Rewrite git:// with https://
+### Rewrite `git://` with `https://`
 
 ```sh
 git config --global url."https://github".insteadOf git://github

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ git config --global url."https://github".insteadOf git://github
  git config --global url."git@github.com:".insteadOf "https://github.com/"
  ```
 
-**Credit:** [@grawity](https://gist.github.com/grawity/4392747) & [@hansdg1](https://github.com/hansdg1) by way of [Kovrinic](https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a)
+**Credit:** [@grawity](https://github.com/grawity/) & [@hansdg1](https://github.com/hansdg1) by way of [@Kovrinic's gist](https://gist.github.com/Kovrinic/ea5e7123ab5c97d451804ea222ecd78a)
 
 ## Contributing
 


### PR DESCRIPTION
# Description

https://gist.github.com/grawity/4392747 is 404, remove

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script or `git` alias
- [x] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
- [ ] I have confirmed that the link(s) in my PR are valid.
