### PR TITLE
fix: Quoting, array, and compatability bugs

### DIFF
--- a/bin/git-attic
+++ b/bin/git-attic
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # git-attic [-M] [PATH] - list deleted files of Git repositories
 #
 # Use -M to not show renamed files, and other git-log options as you like.

--- a/bin/git-flush
+++ b/bin/git-flush
@@ -6,8 +6,8 @@
 # as possible, by dropping all reflogs, stashes, and other cruft that may
 # be bloating your pack files.
 
-/bin/rm -fr .git/refs/original
-/bin/rm -fr .git/refs/snapshots
+rm -fr .git/refs/original
+rm -fr .git/refs/snapshots
 
 if [ -f .git/info/refs ]; then
     perl -i -ne 'print unless /refs\/original/;' .git/info/refs

--- a/bin/git-open-jira
+++ b/bin/git-open-jira
@@ -50,7 +50,7 @@ function jira-open(){
   open "${1}/browse/${$2}"
 }
 
-if !has open; then
+if ! has open; then
   fail "Could not find 'open' in your PATH"
 fi
 

--- a/bin/git-prune-branches
+++ b/bin/git-prune-branches
@@ -22,7 +22,7 @@ fi
 
 merged=$(git branch --no-color --merged "$PRIMARY_BRANCH" | grep -v "$PRIMARY_BRANCH" | sed 's/\*/ /')
 
-if [ ! -z "$merged" ] ; then
+if [ -n "$merged" ] ; then
   echo "Deleting the following merged branches:"
   for branch in $merged ; do
     echo "    " "$branch"

--- a/bin/git-purge-from-history
+++ b/bin/git-purge-from-history
@@ -21,8 +21,7 @@ if [[ ! -d .git ]]; then
 fi
 
 # remove all paths passed as arguments from the history of the repo
-# shellcheck disable=SC2124
-files=$@
+files=$*
 git filter-branch --index-filter "git rm -rf --cached --ignore-unmatch $files" HEAD
 
 # remove the temporary history git-filter-branch otherwise leaves behind for a long time

--- a/bin/git-remove-conflicts
+++ b/bin/git-remove-conflicts
@@ -49,7 +49,7 @@ fi
 for item in "$@"; do
     if [[ -d "$item" && $recursed == false ]]; then
 	if [[ $(basename "$item") != .git ]]; then
-	    git ls-files -z -u "$item" | xargs -0 $0 --recursed $wipe
+	    git ls-files -z -u "$item" | xargs -0 "$0" --recursed $wipe
 	fi
     elif [[ -f "$item" ]]; then
 	echo Removing $wipe from: $item

--- a/bin/git-replace-author
+++ b/bin/git-replace-author
@@ -16,8 +16,8 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
-if [[ ! has git-filter-branch ]]; then
-  myname=$(basename $0)
+if ! has git-filter-branch; then
+  myname=$(basename "$0")
   fail "Usage: $myname OLDNAME NEW_NAME NEW_EMAIL"
 fi
 

--- a/bin/git-up
+++ b/bin/git-up
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Usage: git-up
 #        git-reup
@@ -14,21 +14,17 @@
 
 set -e
 
-# shellcheck disable=SC2124
-PULL_ARGS="$@"
+PULL_ARGS=("$@")
 
 # when invoked as git-reup, run as `git pull --rebase'
-# shellcheck disable=SC2086,SC2124
-test "$(basename $0)" = "git-reup" &&
-PULL_ARGS="--rebase $PULL_ARGS"
+test "$(basename "$0")" = "git-reup" &&
+PULL_ARGS=("--rebase" "${PULL_ARGS[@]}")
 
-# shellcheck disable=SC2086
-git pull $PULL_ARGS
+git pull "${PULL_ARGS[@]}"
 
 # show diffstat of all changes if we're pulling with --rebase. not
 # sure why git-pull only does this when merging.
-# shellcheck disable=SC2086
-test "$(basename $0)" = "git-reup" && {
+test "$(basename "$0")" = "git-reup" && {
     echo "Diff:"
     # shellcheck disable=SC1083
     git --no-pager diff --color --stat HEAD@{1}.. |

--- a/bin/git-up-old
+++ b/bin/git-up-old
@@ -14,17 +14,17 @@
 
 set -e
 
-PULL_ARGS="$@"
+PULL_ARGS=("$@")
 
 # when invoked as git-reup, run as `git pull --rebase'
-test "$(basename $0)" = "git-reup" &&
-PULL_ARGS="--rebase $PULL_ARGS"
+test "$(basename "$0")" = "git-reup" &&
+PULL_ARGS=("--rebase" "${PULL_ARGS[@]}")
 
-git pull "$PULL_ARGS"
+git pull "${PULL_ARGS[@]}"
 
 # show diffstat of all changes if we're pulling with --rebase. not
 # sure why git-pull only does this when merging.
-test "$(basename $0)" = "git-reup" && {
+test "$(basename "$0")" = "git-reup" && {
     echo "Diff:"
     git --no-pager diff --color --stat HEAD@{1}.. |
     sed 's/^/ /'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Mark `bin/git-open-jira` as executable (only file in `bin/` that wasn't marked as such)
- Fix quoting `$0` issues
- Handle `PULL_ARGS` as an array (fixes whitespace/quoting issues)
- Change one shebang from `#!/bin/sh` to `#!/usr/bin/env bash` because it used `set -o pipefail`, which isn't in POSIX (Bashism)

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/update a helper script or `git` alias
- [ ] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [x] If there was no author credit inside a script added in this PR, I have added one.
- [x] I have confirmed that the link(s) in my PR are valid.
