### PR TITLE
Fix git-incoming/git-outgoing

### DIFF
--- a/bin/git-incoming
+++ b/bin/git-incoming
@@ -10,7 +10,7 @@ if [[ "${CURRENT_BRANCH}" != "" ]] {
   TRACKED_REPOSITORY="$(git config branch.${CURRENT_BRANCH}.remote)"
 
   if [[ "${TRACKED_REPOSITORY}" != "" ]] {
-    REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | cut -d"/" -f3)"
+    REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | cut -d"/" -f3-)"
 
     if [[ "${REMOTE_BRANCH}" != "" ]] {
       TARGET="${TRACKED_REPOSITORY}/${REMOTE_BRANCH}"

--- a/bin/git-outgoing
+++ b/bin/git-outgoing
@@ -10,7 +10,7 @@ if [[ "${CURRENT_BRANCH}" != "" ]] {
     TRACKED_REPOSITORY="$(git config branch.${CURRENT_BRANCH}.remote)"
 
     if [[ "${TRACKED_REPOSITORY}" != "" ]] {
-        REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | cut -d"/" -f3)"
+        REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | cut -d"/" -f3-)"
 
         if [[ "${REMOTE_BRANCH}" != "" ]] {
             TARGET="${TRACKED_REPOSITORY}/${REMOTE_BRANCH}"


### PR DESCRIPTION
`cut -d"/" -f3` will break branches of the form
'dependabot/pip/platformdirs-4.1.0'. Since we only need to cut 'refs/heads' part, select all strings starting with third when cutting