### PR TITLE
gitready.com is not resolving.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@
 
 <!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->
 
-- [ ] Add/update a helper script or `git` alias
-- [ ] Add/update link to an external resource like a blog post or video
+- [ ] Add/Remove/Update a helper script or `git` alias
+- [ ] Add/Remove/Update link to an external resource like a blog post or video
 - [ ] Text cleanups/updates
 - [ ] Test updates
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ If you aren't using any ZSH frameworks, or if you're using `bash`, `fish` or ano
 - [git-tips/tips](https://github.com/git-tips/tips) is a collection of `git` tips.
 - [git-tips](http://mislav.net/2010/07/git-tips/) by Mislav Marohnić is a good article on `git` tips. Several of his `git` scripts are in this collection.
 - [gitimmersion.com/](http://gitimmersion.com/) is a guided tour that walks through the fundamentals of Git, inspired by the premise that to know a thing is to do it.
-- [gitready.com/](http://gitready.com/) is a great reference which has been collecting information and tips for `git` since 2009.
 - [learnenough.com](http://www.learnenough.com/git-tutorial) has a more detailed `git` tutorial on
 - [“Git” it together: Some tips on commit etiquette and best practices for junior developers](https://hackernoon.com/git-it-together-some-tips-on-commit-etiquette-and-best-practices-for-junior-developers-1f147b8dfd56) is a good article explaining some best practices on how to write a _good_ commit message, no matter what source control system you're using.
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

# Description

Remove gitready.com link, it's not resolving

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/update a helper script or `git` alias
- [x] Add/update link to an external resource like a blog post or video
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
