### PR TITLE
Add `git-add-match`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you wrote one of these scripts and want it removed from this collection, plea
 
 | Script | Original Source | Description |
 | ------ | --------------- | ----------- |
+| `git-add-match` | [Git: programmatic staging](https://choly.ca/post/git-programmatic-staging/) | Allows you to use `expect` to automatically stage hunks matching a search term |
 | `git-add-username-remote` | Ryan Tomayko's dotfiles | Adds a remote for the current repository for the given GitHub username. |
 | `git-age` | Kristoffer Gronlund's [wiki](https://github.com/krig/git-age/wiki) | A git-blame viewer, written using PyGTK. |
 | `git-amend-all` | John Wiegley's [git scripts](https://github.com/jwiegley/git-scripts) | Adds all modified and deleted files, except the new files and adds them to the recent commit by amending it. |

--- a/bin/git-add-match
+++ b/bin/git-add-match
@@ -1,0 +1,32 @@
+#!/usr/bin/env expect -f
+#
+# Original source: https://choly.ca/post/git-programmatic-staging
+
+# Set timeout to prevent the script from hanging
+set timeout -1
+
+# Get the search pattern as a command line argument
+if {[llength $argv] != 0} {
+   set pattern [lindex $argv 0]
+} else {
+   puts "Error: search pattern not provided"
+   exit 1
+}
+
+# Open the interaction with git add -p
+spawn git add -p
+
+# This is the main loop that handles the user interaction
+expect {
+  # This expect block is for the hunk that contains the provided pattern
+  "*$pattern*Stage this hunk*" {
+    send "y\r"
+    exp_continue
+  }
+  # This expect block is for continuing to the next hunk
+  "*Stage this hunk*" {
+    send "n\r"
+    exp_continue
+  }
+  eof
+}


### PR DESCRIPTION
# Description

Add `git-add-match` from [Git: programmatic staging](https://choly.ca/post/git-programmatic-staging/) blog post

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/Remove/Update a helper script or `git` alias
- [ ] Add/Remove/Update link to an external resource like a blog post or video
- [ ] Plugin file updates - functions added here probably should be standalone scripts in `/bin`
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] All new and existing tests pass.
- [x] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [x] If there was no author credit inside a script added in this PR, I have added one.
