### PR TITLE
Update git-authors - remove "WHERE"

### DIFF
--- a/bin/git-authors
+++ b/bin/git-authors
@@ -7,4 +7,4 @@ if [[ $# == 1 ]]; then
   WHERE="$1"
 fi
 
-exec git log --pretty=format:'%an <%ae>' "$WHERE" | sort | uniq -c | sort -nr
+exec git log --pretty=format:'%an <%ae>' | sort | uniq -c | sort -nr


### PR DESCRIPTION
Having "WHERE" in:

```
git log --pretty=format:'%an <%ae>' "$WHERE" | sort | uniq -c | sort -nr
```

was breaking the command. "WHERE" was removed, what fixes the command.