### PR TITLE
Fix `git-open-jira`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you wrote one of these scripts and want it removed from this collection, plea
 | `git-nuke` | Zach Holman's [dotfiles](https://github.com/holman/dotfiles) | Nukes a branch locally and on the origin remote. |
 | `git-object-deflate` | Ryan Tomayko's dotfiles | Deflate an loose object file and write to standard output. |
 | `git-oldest-common-ancestor` | Lee Dohm's [dotfiles](https://github.com/lee-dohm/dotfiles/blob/main/bin/git-oldest-ancestor) | Finds the oldest common ancestor commit between two branches. |
-| `git-open-jira` | If the branch name starts with `JIRAPROJECT-NNNN`, will open that issue in jira. Assumes that your JIRA server location is in `~/.jira-server` or in the `$JIRA_SERVER` environment variable. |
+| `git-open-jira` | ? | If the branch name starts with `JIRAPROJECT-NNNN`, will open that issue in jira. Assumes that your JIRA server location is in `~/.jira-server` or in the `$JIRA_SERVER` environment variable. |
 | `git-origin-head` | Don't recall, maybe twitter | Prints the name of the origin remote's default branch. Not every repository uses `main` or `master`. |
 | `git-outgoing` | Michael Markert's [dotfiles](https://github.com/cofi/dotfiles) | Show commits that are on the local branch that have not been pushed to the tracking branch. |
 | `git-overwritten` | Mislav Marohnić's [dotfiles](https://github.com/mislav/dotfiles) | Aggregates `git blame` information about original owners of lines changed or removed in the '<base>...<head>' diff. |


### PR DESCRIPTION
# Description

Fix format of `git-open-jira` entry

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/Remove/Update a helper script or `git` alias
- [ ] Add/Remove/Update link to an external resource like a blog post or video
- [ ] Plugin file updates - functions added here probably should be standalone scripts in `/bin`
- [x] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
