### PR TITLE
Add ZSH and bash completions

### DIFF
--- a/completions/_git-extra-commands
+++ b/completions/_git-extra-commands
@@ -1,0 +1,1072 @@
+#compdef git
+# Copyright 2006-2026 Joseph Block <jpb@apesseekingknowledge.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Zsh completion functions for git-extra-commands
+
+# Register subcommand descriptions for 'git <TAB>'
+# Symlinks (aliases to other commands) are included so they complete too:
+#   git-branch-clean -> git-brcl
+#   git-changes -> git-authors
+#   git-credit-author -> git-credit
+#   git-current-branch -> git-branch-name
+#   git-delete-local-merged -> git-delete-merged-branches
+#   git-list-semvers -> git-semvers
+#   git-most-changed -> git-mostchanged
+#   git-pr-fetch -> git-fetch-prs
+#   git-reup -> git-up
+zstyle ':completion:*:*:git:*' user-commands \
+  add-match:'Use expect to automatically stage hunks matching a search term' \
+  add-username-remote:'Add a remote for the current repository for the given GitHub username' \
+  amend-all:'Add all modified and deleted files and amend them to the recent commit' \
+  attic:'Display a list of deleted files in your repository' \
+  authors:'List authors in the repository in descending commit-count order' \
+  big-file:'Show files in the repository larger than a threshold size' \
+  branch-clean:'Remove various copies of a branch' \
+  branch-date:'List branches in commit-date order' \
+  branch-diff:'Diff your current HEAD with the default branch of the origin remote' \
+  branch-name:'Print the current branch name in automation-friendly format' \
+  branch-rebaser:'Kick off an interactive rebase of all commits on your branch' \
+  branch-status:'Colorized status report on all branches in your repository' \
+  branches:'List all branches' \
+  branches-that-touch:'Show branches that touch files under a given path' \
+  brcl:'Remove various copies of a branch' \
+  bug-clusters:'Show files with the most bugfix comments in commits' \
+  capture-wip:'Capture in-progress file changes' \
+  change-author:'Change one author/email in the history to another' \
+  changelog:'Transform git log output into a Changelog' \
+  changes:'List authors in the repository in descending commit-count order' \
+  checkout-branches:'Check out all remote branches' \
+  checkout-by-date:'Check out files at the version specified by a date' \
+  checkout-commit:'Use fzf to checkout a commit with diff preview' \
+  checkout-default-branch:'Check out the default branch of the origin remote' \
+  checkout-latest-tag:'Check out the latest tag' \
+  checkout-pr:'Check out a PR locally' \
+  checkout-preview:'Use fzf to checkout a branch with divergence preview' \
+  checkout-tag:'Check out a tag into a branch named after the tag' \
+  children-of:'Show the children of a given git commit' \
+  churn:'Show which files are getting changed most often in the repository' \
+  clone-subset:'Clone and filter-branch to keep only specified files and history' \
+  comma:'Add and commit a file in one command' \
+  commit-browser:'Use fzf to browse commit history' \
+  commit-count:'Get the number of commits on the current branch' \
+  commits-per-day:'Show the average number of commits per day' \
+  compact:'Compact a git repo aggressively' \
+  conflicts:'Show files with conflicts' \
+  copy-branch-name:'Copy the current branch name to the clipboard' \
+  credit:'Quicker way to assign credit to another author on the latest commit' \
+  credit-author:'Quicker way to assign credit to another author on the latest commit' \
+  current-branch:'Print the name of the current branch for use in automation' \
+  current-commit:'Print the hash of the current commit for use in automation' \
+  cut-branch:'Create a new named branch pointed at HEAD and reset the current branch to the head of its tracking branch' \
+  delete-dangling-commits:'Clean up dangling commits that are not on any branch' \
+  delete-local-merged:'Delete all local branches that have been merged into HEAD' \
+  delete-merged-branches:'Purge all branches that have been merged to a target branch' \
+  delete-remote-branch:'Delete a branch from a specified remote' \
+  delete-squashed-and-merged-branches:'Purge branches that have been squashed and merged to a target branch' \
+  delete-tag:'Delete a tag locally and from the origin remote' \
+  diff-last:'Show the last change made to a file in the repository' \
+  divergence:'Show differences between local branch and its tracking branch' \
+  edit-conflicts:'Edit conflicted files in your editor' \
+  fetch-prs:'Get all Pull Request branches from a given remote by refspec' \
+  files:'List files different between the current branch and the default branch' \
+  find-dirty:'Recurse current directory, listing dirty git clones' \
+  firefights:'Show revert and hotfix frequency' \
+  flush:'Compact your repository by dropping all reflogs, stashes, and cruft' \
+  force-mtimes:'Set modification times of all files to their last change date' \
+  forest:'Print a text-based tree visualization of your repository' \
+  functionlog:'Get a git log of a particular function, not a file' \
+  fzf-add:'Use fzf to select files to add to git' \
+  fzf-log-browser:'Use fzf to browse the git log' \
+  fzf-pickaxe-browser:'Use fzf to display a git log filtered with pickaxe for a search term' \
+  fzf-reflog-browser:'Use fzf to browse the git reflog' \
+  git:'Make git git foo do a git foo instead of complaining' \
+  github-open:'Open GitHub file/blob page for FILE on LINE' \
+  gitlab-mr:'Open a merge request on GitLab' \
+  history-eraser:'Permanently delete files/folders from your git repository' \
+  history-graph:'Pretty git log, single line per commit, with branch graphing' \
+  ignored:'Show files being ignored by git in the repository' \
+  improved-merge:'Sophisticated git merge with integrated CI check and automatic cleanup' \
+  incoming:'Show commits in the tracking branch that are not in the local branch' \
+  jump:'Replay git commits by moving forward/backward through branch history' \
+  latest-tag:'Fetch tags from all remotes and show the most recent tag name' \
+  lines:'List author names with line counts for files with a specified extension' \
+  list-semvers:'List all semver-compliant tags in the repo' \
+  log-single-file:'Show the log for a single file' \
+  ls-branch-files:'List files changed between a specified branch and the current branch' \
+  ls-conflicts:'List files with conflicts' \
+  ls-object-refs:'Find references to an object SHA1 in refs, commits, and trees' \
+  make-gitignore:'Print a language-specific .gitignore file using gitignore.io' \
+  mark-all-resolved:'Mark all conflicted files as resolved' \
+  maxpack:'Compress a repository pack files as much as possible' \
+  merged-branches:'List all branches that have been merged' \
+  most-changed:'Show files with the most changes' \
+  mostchanged:'Show the files with the most changes over the last year' \
+  move-commits:'Move the last n commits to a different branch' \
+  neck:'Show commits from HEAD until the first branching point' \
+  nuke:'Nuke a branch locally and on the origin remote' \
+  nuke-untracked-files:'Delete untracked files from a git clone tree' \
+  object-deflate:'Deflate a loose object file and write to standard output' \
+  oldest-common-ancestor:'Find the oldest common ancestor commit between two branches' \
+  open-jira:'Open the JIRA issue from the branch name in your browser' \
+  origin-head:'Print the name of the origin remote default branch' \
+  outgoing:'Show commits on the local branch that have not been pushed' \
+  overwritten:'Aggregate git blame info about original owners of changed lines' \
+  pie-ify:'Apply perl pie on the fly' \
+  plotrepo:'Use dot to draw a graph of the repository' \
+  pr-fetch:'Fetch PR branches by refspec from a remote' \
+  pr-list:'List pull requests (requires gh)' \
+  promote:'Promote a local topic branch to a remote tracking branch of the same name' \
+  prune-branches:'Delete each fully merged branch after prompting for confirmation' \
+  pruneall:'Prune branches from specified remotes, or all remotes when none specified' \
+  publish:'Push/publish current branch to specified remote' \
+  purge-from-history:'Permanently delete files or folders from your git repository' \
+  pylint:'Run pylint on .py files modified or added in git status output' \
+  rank-contributors:'Rank contributors by the total size of the diffs they are responsible for' \
+  rebase-authors:'Add authorship info to interactive git rebase output' \
+  rebase-theirs:'Resolve rebase conflicts by favoring theirs version' \
+  rebase-work-in-progress:'Interactive rebase of unpushed commits on the current branch' \
+  recent:'Show information about the most recent commit on all local branches' \
+  recently-checkedout-branches:'Show timestamp and name of recently checked-out branches' \
+  ref-recent:'Show date, branch name, hash, and subject of branches by recency' \
+  rel:'Show the relationship between the current branch and a ref' \
+  related:'Show other files that often get changed in commits that touch a file' \
+  release-tag:'Create a GitHub release for a specified tag' \
+  remote-default-branch:'Show the default branch for a specified remote' \
+  remove-conflicts:'Automatically resolve conflicts by applying ours or theirs' \
+  rename-branches:'Rename multiple branches that start with a given name' \
+  replace-author:'Rewrite all commits with one name to use another name and email' \
+  reset-with-fire:'Hard reset the working directory and zap files not known to git' \
+  restore-mtime:'Change mtime of files based on commit date of last change' \
+  review-commits:'Use fzf to preview commits' \
+  rm-deleted-from-repo:'Remove files you deleted with rm from the repository' \
+  root-directory:'Print the path to the root of the git repository' \
+  roots:'Show all parentless commits in the repository' \
+  run-command-on-revisions:'Run a given command over a range of git revisions' \
+  semvers:'List all semver-compliant tags in the repo' \
+  shamend:'Amend staged changes as a fixup to the specified older commit' \
+  show-overwritten:'Aggregate git blame info about original owners of changed lines' \
+  shrink-repo:'Shrink your clone of a git repository' \
+  side-by-side:'Do a side-by-side diff similar to GitHub PRs' \
+  sp:'Simple push - commit and push. Use -a flag to add all files' \
+  sr:'Use fzf to switch to a different git ref' \
+  stashes:'List stash entries' \
+  stats:'Display stats for files different between current branch and default branch' \
+  submodule-ls:'List all submodules in your project' \
+  submodule-paths:'Show path to all submodules with their current commit SHA' \
+  submodule-rm:'Remove a submodule easily' \
+  superpull:'Pull, then run submodule init and submodule update' \
+  switch-branch:'Switch to a branch by a substring of its name' \
+  tag-and-sign:'Create and sign a new tag' \
+  tag-diff:'Show differences between local tags and ones on the remote' \
+  taglist:'List tags sorted by version, showing the most recent' \
+  tags:'List tags with their annotations' \
+  thanks:'List contributors in descending commit order' \
+  track:'Set up your branch to track a remote branch' \
+  trail:'Show all branching points in the repository git history' \
+  undelete:'Undelete a file' \
+  undo:'Undo the last commit but keep the changes in place' \
+  undo-push:'Undo your last push to a branch of origin' \
+  unpushed:'Show the diff of everything you have not pushed yet' \
+  unpushed-stat:'Show the diffstat of everything you have not pushed yet' \
+  unreleased:'Show git commits since the last tagged version' \
+  up:'Like git pull but show a short and sexy log of changes after merging or rebasing' \
+  up-old:'Like git pull but show a short and sexy log of changes after merging or rebasing' \
+  upstream-name:'Print the name of the current branch upstream' \
+  upstream-sync:'Fetch upstream/yourforkname and rebase into your local fork, then push' \
+  velocity:'Show commit count by month for the entire history of the repo' \
+  what-the-hell-just-happened:'Show what just happened' \
+  when-merged:'Find when a commit was merged into one or more branches' \
+  where:'Show where a particular commit falls between releases' \
+  where-pr:'Open the Pull Request on GitHub where a specified commit originated' \
+  whoami:'Show what username and email you have configured for the repository' \
+  winner:'Show what authors have made the most commits by count and lines changed' \
+  wordiness:'Show how wordy commit messages are per contributor' \
+  wtf:'Display the state of your repository in a readable, easy-to-scan format'
+
+# Helper: complete git branch names
+__git_extra_branch_names() {
+  local -a branches
+  branches=(${${(f)"$(git branch --format='%(refname:short)' 2>/dev/null)"}})
+  _describe 'branch' branches
+}
+
+# Helper: complete git remote branch names
+__git_extra_remote_branch_names() {
+  local -a branches
+  branches=(${${(f)"$(git branch -r --format='%(refname:short)' 2>/dev/null)"}})
+  _describe 'remote branch' branches
+}
+
+# Helper: complete git remote names
+__git_extra_remote_names() {
+  local -a remotes
+  remotes=(${${(f)"$(git remote 2>/dev/null)"}})
+  _describe 'remote' remotes
+}
+
+# Helper: complete git tag names
+__git_extra_tag_names() {
+  local -a tags
+  tags=(${${(f)"$(git tag -l 2>/dev/null)"}})
+  _describe 'tag' tags
+}
+
+# Helper: complete tracked files
+__git_extra_tracked_files() {
+  local -a files
+  files=(${${(f)"$(git ls-files 2>/dev/null)"}})
+  _describe 'file' files
+}
+
+# Helper: complete modified files
+__git_extra_modified_files() {
+  local -a files
+  files=(${${(f)"$(git diff --name-only 2>/dev/null)"}})
+  _describe 'modified file' files
+}
+
+# Helper: complete conflicted files
+__git_extra_conflicted_files() {
+  local -a files
+  files=(${${(f)"$(git diff --name-only --diff-filter=U 2>/dev/null)"}})
+  _describe 'conflicted file' files
+}
+
+# Helper: complete commit refs
+__git_extra_commits() {
+  _alternative \
+    'branches:branch:__git_extra_branch_names' \
+    'tags:tag:__git_extra_tag_names'
+}
+
+# --- Individual command completions ---
+
+_git-add-match() {
+  _arguments \
+    '1:search pattern:'
+}
+
+_git-add-username-remote() {
+  _arguments \
+    '1:github username:'
+}
+
+_git-amend-all() {
+  _message 'no arguments'
+}
+
+_git-attic() {
+  _message 'no arguments'
+}
+
+_git-authors() {
+  _arguments \
+    '1::path - limit to commits touching this path:_files'
+}
+
+_git-big-file() {
+  _arguments \
+    '1::ref:__git_extra_commits' \
+    '2::threshold in MB:'
+}
+
+_git-branch-clean() {
+  _arguments \
+    '1:branch name:__git_extra_branch_names'
+}
+
+_git-branch-date() {
+  _message 'no arguments'
+}
+
+_git-branch-diff() {
+  _arguments \
+    '1::branch:__git_extra_branch_names'
+}
+
+_git-branch-name() {
+  _message 'no arguments'
+}
+
+_git-branch-rebaser() {
+  _arguments \
+    '1::branch:__git_extra_branch_names'
+}
+
+_git-branch-status() {
+  _message 'no arguments'
+}
+
+_git-branches() {
+  _message 'no arguments'
+}
+
+_git-branches-that-touch() {
+  _arguments \
+    '1:path:_files'
+}
+
+_git-brcl() {
+  _arguments \
+    '1:branch name:__git_extra_branch_names'
+}
+
+_git-bug-clusters() {
+  _message 'no arguments'
+}
+
+_git-capture-wip() {
+  _message 'no arguments'
+}
+
+_git-change-author() {
+  _arguments \
+    '1:old author name or email:' \
+    '2:new author name:' \
+    '3:new author email:'
+}
+
+_git-changelog() {
+  _message 'no arguments'
+}
+
+_git-changes() {
+  _arguments \
+    '1::path - limit to commits touching this path:_files'
+}
+
+_git-checkout-branches() {
+  _message 'no arguments'
+}
+
+_git-checkout-by-date() {
+  _arguments \
+    '1:date (YYYY-MM-DD):' \
+    '*:files:__git_extra_tracked_files'
+}
+
+_git-checkout-commit() {
+  _message 'interactive fzf selection'
+}
+
+_git-checkout-default-branch() {
+  _message 'no arguments'
+}
+
+_git-checkout-latest-tag() {
+  _message 'no arguments'
+}
+
+_git-checkout-pr() {
+  _arguments \
+    '1:PR number or "clean":' \
+    '2::remote:__git_extra_remote_names'
+}
+
+_git-checkout-preview() {
+  _message 'interactive fzf selection'
+}
+
+_git-checkout-tag() {
+  _arguments \
+    '1:tag:__git_extra_tag_names'
+}
+
+_git-children-of() {
+  _arguments \
+    '1:commit:__git_extra_commits'
+}
+
+_git-churn() {
+  _arguments \
+    '*:git log arguments (e.g. --since="1 month ago" or paths):'
+}
+
+_git-clone-subset() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '1:repository URL or path:_files -/' \
+    '2:destination directory:_files -/' \
+    '3:file pattern:'
+}
+
+_git-comma() {
+  _arguments \
+    '*:files:_files'
+}
+
+_git-commit-browser() {
+  _message 'interactive fzf selection'
+}
+
+_git-commit-count() {
+  _message 'no arguments'
+}
+
+_git-commits-per-day() {
+  _message 'no arguments'
+}
+
+_git-compact() {
+  _message 'no arguments'
+}
+
+_git-conflicts() {
+  _message 'no arguments'
+}
+
+_git-copy-branch-name() {
+  _message 'no arguments'
+}
+
+_git-credit() {
+  _arguments \
+    '1:author name:' \
+    '2:author email:'
+}
+
+_git-credit-author() {
+  _arguments \
+    '1:author name:' \
+    '2:author email:'
+}
+
+_git-current-branch() {
+  _message 'no arguments'
+}
+
+_git-current-commit() {
+  _message 'no arguments'
+}
+
+_git-cut-branch() {
+  _arguments \
+    '1:new branch name:'
+}
+
+_git-delete-dangling-commits() {
+  _message 'no arguments'
+}
+
+_git-delete-local-merged() {
+  _message 'no arguments'
+}
+
+_git-delete-merged-branches() {
+  _arguments \
+    '1::target branch:__git_extra_branch_names'
+}
+
+_git-delete-remote-branch() {
+  _arguments \
+    '1:remote:__git_extra_remote_names' \
+    '2:branch name:__git_extra_remote_branch_names'
+}
+
+_git-delete-squashed-and-merged-branches() {
+  _arguments \
+    '1::target branch:__git_extra_branch_names'
+}
+
+_git-delete-tag() {
+  _arguments \
+    '1:tag:__git_extra_tag_names'
+}
+
+_git-diff-last() {
+  _arguments \
+    '1:file:__git_extra_tracked_files'
+}
+
+_git-divergence() {
+  _arguments \
+    '1::local branch:__git_extra_branch_names' \
+    '2::remote branch:__git_extra_remote_branch_names'
+}
+
+_git-edit-conflicts() {
+  _message 'no arguments'
+}
+
+_git-fetch-prs() {
+  _arguments \
+    '1::remote:__git_extra_remote_names'
+}
+
+_git-files() {
+  _message 'no arguments'
+}
+
+_git-find-dirty() {
+  _arguments \
+    '1::directory:_files -/'
+}
+
+_git-firefights() {
+  _message 'no arguments'
+}
+
+_git-flush() {
+  _message 'no arguments'
+}
+
+_git-force-mtimes() {
+  _message 'no arguments'
+}
+
+_git-forest() {
+  _arguments \
+    '--all[show all branches]' \
+    '--no-color[disable color output]' \
+    '--no-rebase[do not show rebase info]' \
+    '-a[show author names]' \
+    '--reverse[reverse output order]' \
+    '--sha[show commit SHA alongside messages]' \
+    '--style=[graph style 1, 2, 10, or 15]:style:(1 2 10 15)' \
+    '--svdepth=[subvine depth]:depth:' \
+    '--pretty=[format string (must be format:...)]:format:' \
+    '*:git log arguments:'
+}
+
+_git-functionlog() {
+  _arguments \
+    '1:function name:' \
+    '2:file:__git_extra_tracked_files'
+}
+
+_git-fzf-add() {
+  _message 'interactive fzf selection'
+}
+
+_git-fzf-log-browser() {
+  _message 'interactive fzf selection'
+}
+
+_git-fzf-pickaxe-browser() {
+  _arguments \
+    '1:search term:'
+}
+
+_git-fzf-reflog-browser() {
+  _message 'interactive fzf selection'
+}
+
+_git-git() {
+  _arguments '*:git arguments:'
+}
+
+_git-github-open() {
+  _arguments \
+    '1:file:__git_extra_tracked_files' \
+    '2::line number:'
+}
+
+_git-gitlab-mr() {
+  _arguments \
+    '1::target branch:__git_extra_branch_names'
+}
+
+_git-history-eraser() {
+  _arguments \
+    '*:paths to delete:_files'
+}
+
+_git-history-graph() {
+  _message 'no arguments'
+}
+
+_git-ignored() {
+  _message 'no arguments'
+}
+
+_git-improved-merge() {
+  _arguments \
+    '1::branch:__git_extra_branch_names'
+}
+
+_git-incoming() {
+  _arguments \
+    '1::remote/branch:__git_extra_remote_branch_names'
+}
+
+_git-jump() {
+  _arguments \
+    '1:direction:(forward backward)'
+}
+
+_git-latest-tag() {
+  _message 'no arguments'
+}
+
+_git-lines() {
+  _arguments \
+    '1:file extension:'
+}
+
+_git-list-semvers() {
+  _message 'no arguments'
+}
+
+_git-log-single-file() {
+  _arguments \
+    '1:file:__git_extra_tracked_files'
+}
+
+_git-ls-branch-files() {
+  _arguments \
+    '1::branch:__git_extra_branch_names'
+}
+
+_git-ls-conflicts() {
+  _message 'no arguments'
+}
+
+_git-ls-object-refs() {
+  _arguments \
+    '1:object SHA1:'
+}
+
+_git-make-gitignore() {
+  _arguments \
+    '*:language/framework:'
+}
+
+_git-mark-all-resolved() {
+  _message 'no arguments'
+}
+
+_git-maxpack() {
+  _message 'no arguments'
+}
+
+_git-merged-branches() {
+  _message 'no arguments'
+}
+
+_git-most-changed() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '(-n --num-files --numfiles)'{-n,--num-files,--numfiles}'[number of files to show]:number:'
+}
+
+_git-mostchanged() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '(-n --num-files --numfiles)'{-n,--num-files,--numfiles}'[number of files to show]:number:'
+}
+
+_git-move-commits() {
+  _arguments \
+    '1:number of commits:' \
+    '2:target branch:__git_extra_branch_names'
+}
+
+_git-neck() {
+  _arguments \
+    '1::commit:__git_extra_commits'
+}
+
+_git-nuke() {
+  _arguments \
+    '1:branch:__git_extra_branch_names'
+}
+
+_git-nuke-untracked-files() {
+  _message 'no arguments'
+}
+
+_git-object-deflate() {
+  _arguments \
+    '1:object file:_files'
+}
+
+_git-oldest-common-ancestor() {
+  _arguments \
+    '1:branch A:__git_extra_branch_names' \
+    '2:branch B:__git_extra_branch_names'
+}
+
+_git-open-jira() {
+  _message 'no arguments'
+}
+
+_git-origin-head() {
+  _message 'no arguments'
+}
+
+_git-outgoing() {
+  _arguments \
+    '1::remote/branch:__git_extra_remote_branch_names'
+}
+
+_git-overwritten() {
+  _arguments \
+    '1::base ref:__git_extra_commits' \
+    '2::head ref:__git_extra_commits'
+}
+
+_git-pie-ify() {
+  _arguments \
+    '1:search pattern:' \
+    '2:replacement:'
+}
+
+_git-plotrepo() {
+  _message 'no arguments'
+}
+
+_git-pr-fetch() {
+  _arguments \
+    '1::remote:__git_extra_remote_names'
+}
+
+_git-pr-list() {
+  _message 'no arguments'
+}
+
+_git-promote() {
+  _arguments \
+    '1::remote:__git_extra_remote_names' \
+    '2::branch:__git_extra_branch_names'
+}
+
+_git-prune-branches() {
+  _message 'no arguments'
+}
+
+_git-pruneall() {
+  _arguments \
+    '*::remote:__git_extra_remote_names'
+}
+
+_git-publish() {
+  _arguments \
+    '1:remote:__git_extra_remote_names' \
+    '2::remote branch:'
+}
+
+_git-purge-from-history() {
+  _arguments \
+    '*:paths to delete:_files'
+}
+
+_git-pylint() {
+  _message 'no arguments'
+}
+
+_git-rank-contributors() {
+  _arguments \
+    '-v[verbose - show line counts]' \
+    '-o[obfuscate email addresses]'
+}
+
+_git-rebase-authors() {
+  _message 'no arguments'
+}
+
+_git-rebase-theirs() {
+  _arguments \
+    '*:files:__git_extra_conflicted_files'
+}
+
+_git-rebase-work-in-progress() {
+  _message 'no arguments'
+}
+
+_git-recent() {
+  _message 'no arguments'
+}
+
+_git-recently-checkedout-branches() {
+  _message 'no arguments'
+}
+
+_git-ref-recent() {
+  _message 'no arguments'
+}
+
+_git-rel() {
+  _arguments \
+    '1::ref:__git_extra_commits'
+}
+
+_git-related() {
+  _arguments \
+    '1:file:__git_extra_tracked_files'
+}
+
+_git-release-tag() {
+  _arguments \
+    '1:tag:__git_extra_tag_names'
+}
+
+_git-remote-default-branch() {
+  _arguments \
+    '1::remote:__git_extra_remote_names'
+}
+
+_git-remove-conflicts() {
+  _arguments \
+    '1:strategy:(ours theirs)' \
+    '*:files:__git_extra_conflicted_files'
+}
+
+_git-rename-branches() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '(-v --verbose)'{-v,--verbose}'[print more details]' \
+    '(-n --dry-run)'{-n,--dry-run}'[do not actually rename]' \
+    '1:branch prefix:' \
+    '2:new prefix:'
+}
+
+_git-replace-author() {
+  _arguments \
+    '1:old name:' \
+    '2:new name:' \
+    '3:new email:'
+}
+
+_git-reset-with-fire() {
+  _message 'no arguments'
+}
+
+_git-restore-mtime() {
+  _arguments \
+    '*::files:__git_extra_tracked_files'
+}
+
+_git-review-commits() {
+  _message 'interactive fzf selection'
+}
+
+_git-rm-deleted-from-repo() {
+  _message 'no arguments'
+}
+
+_git-root-directory() {
+  _message 'no arguments'
+}
+
+_git-roots() {
+  _message 'no arguments'
+}
+
+_git-run-command-on-revisions() {
+  _arguments \
+    '-v[verbose output]' \
+    '1:start ref:__git_extra_commits' \
+    '2:end ref:__git_extra_commits' \
+    '3:command to run:'
+}
+
+_git-semvers() {
+  _message 'no arguments'
+}
+
+_git-shamend() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '(-a --all)'{-a,--all}'[commit unchanged files]' \
+    '1::revision:__git_extra_commits'
+}
+
+_git-show-overwritten() {
+  _arguments \
+    '1::base ref:__git_extra_commits' \
+    '2::head ref:__git_extra_commits'
+}
+
+_git-shrink-repo() {
+  _message 'no arguments'
+}
+
+_git-side-by-side() {
+  _arguments \
+    '*:files:__git_extra_tracked_files'
+}
+
+_git-sp() {
+  _arguments \
+    '-a[add all files before committing]' \
+    '1:commit message:'
+}
+
+_git-sr() {
+  _message 'interactive fzf selection'
+}
+
+_git-stashes() {
+  _message 'no arguments'
+}
+
+_git-stats() {
+  _message 'uses $REVIEW_BASE env var or origin default branch'
+}
+
+_git-submodule-ls() {
+  _message 'no arguments'
+}
+
+_git-submodule-paths() {
+  _message 'no arguments'
+}
+
+_git-submodule-rm() {
+  _arguments \
+    '1:submodule path:_files -/'
+}
+
+_git-superpull() {
+  _message 'no arguments'
+}
+
+_git-switch-branch() {
+  _arguments \
+    '1:branch substring:'
+}
+
+_git-tag-and-sign() {
+  _arguments \
+    '1:tag name:' \
+    '2::tag message:'
+}
+
+_git-tag-diff() {
+  _message 'no arguments'
+}
+
+_git-taglist() {
+  _message 'no arguments'
+}
+
+_git-tags() {
+  _message 'no arguments'
+}
+
+_git-thanks() {
+  _arguments \
+    '1::revision range (e.g. 0.9.0..master):__git_extra_commits'
+}
+
+_git-track() {
+  _message 'no arguments'
+}
+
+_git-trail() {
+  _arguments \
+    '1::ref:__git_extra_commits'
+}
+
+_git-undelete() {
+  _arguments \
+    '1:file path:'
+}
+
+_git-undo() {
+  _message 'no arguments'
+}
+
+_git-undo-push() {
+  _arguments \
+    '1:branch:__git_extra_branch_names'
+}
+
+_git-unpushed() {
+  _message 'no arguments'
+}
+
+_git-unpushed-stat() {
+  _message 'no arguments'
+}
+
+_git-unreleased() {
+  _message 'shows commits since last tag, no arguments needed'
+}
+
+_git-up() {
+  _arguments \
+    '*:git pull arguments:'
+}
+
+_git-up-old() {
+  _arguments \
+    '*:git pull arguments:'
+}
+
+_git-upstream-name() {
+  _message 'no arguments'
+}
+
+_git-upstream-sync() {
+  _message 'no arguments'
+}
+
+_git-velocity() {
+  _message 'no arguments'
+}
+
+_git-what-the-hell-just-happened() {
+  _message 'no arguments'
+}
+
+_git-when-merged() {
+  _arguments \
+    '1:commit:__git_extra_commits' \
+    '*::branch:__git_extra_branch_names'
+}
+
+_git-where() {
+  _arguments \
+    '1:commit:__git_extra_commits'
+}
+
+_git-where-pr() {
+  _arguments \
+    '1:commit:__git_extra_commits'
+}
+
+_git-whoami() {
+  _message 'no arguments'
+}
+
+_git-winner() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[show help]' \
+    '1::date - show activity after this date (MM-DD-YYYY):'
+}
+
+_git-wordiness() {
+  _arguments \
+    '(-h --help -help)'{-h,--help,-help}'[show help]' \
+    '-s=-[hash author names with optional prefix]:prefix:' \
+    '(-c -csv --csv)'{-c,-csv,--csv}'[output in CSV format]' \
+    '(-t -tsv --tsv)'{-t,-tsv,--tsv}'[output in TSV format]' \
+    '(-nh -nohead --nohead)'{-nh,-nohead,--nohead}'[omit header row]' \
+    '--order=[sort order]:order:(commits c wpc W lines l words w bytes b name n)' \
+    '*:git log arguments:'
+}
+
+_git-wtf() {
+  _arguments \
+    '(-l --long)'{-l,--long}'[include author info and date for each commit]' \
+    '(-a --all)'{-a,--all}'[show all branches across all remote repos]' \
+    '(-A --all-commits)'{-A,--all-commits}'[show all commits, not just the first 5]' \
+    '(-s --short)'{-s,--short}'[do not show commits]' \
+    '(-k --key)'{-k,--key}'[show key]' \
+    '(-r --relations)'{-r,--relations}'[show relation to features / integration branches]' \
+    '--dump-config[print current configuration and exit]' \
+    '*::branch:__git_extra_branch_names'
+}

--- a/completions/git-extra-commands.bash
+++ b/completions/git-extra-commands.bash
@@ -1,0 +1,995 @@
+#!/usr/bin/env bash
+# Copyright 2006-2026 Joseph Block <jpb@apesseekingknowledge.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Bash completion for git-extra-commands
+#
+# Source this file or place it in /etc/bash_completion.d/ or
+# ~/.local/share/bash-completion/completions/
+
+# --- Helper functions ---
+
+__git_extra_branch_names() {
+  git branch --format='%(refname:short)' 2>/dev/null
+}
+
+__git_extra_remote_branch_names() {
+  git branch -r --format='%(refname:short)' 2>/dev/null
+}
+
+__git_extra_remote_names() {
+  git remote 2>/dev/null
+}
+
+__git_extra_tag_names() {
+  git tag -l 2>/dev/null
+}
+
+__git_extra_tracked_files() {
+  git ls-files 2>/dev/null
+}
+
+__git_extra_modified_files() {
+  git diff --name-only 2>/dev/null
+}
+
+__git_extra_conflicted_files() {
+  git diff --name-only --diff-filter=U 2>/dev/null
+}
+
+__git_extra_refs() {
+  { __git_extra_branch_names; __git_extra_tag_names; } 2>/dev/null
+}
+
+# Generate COMPREPLY from a wordlist for the current word
+__git_extra_complete_words() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "$1" -- "$cur"))
+}
+
+# --- Individual command completions ---
+
+_git_add_match() {
+  # arg 1: search pattern (free text)
+  COMPREPLY=()
+}
+
+_git_add_username_remote() {
+  # arg 1: github username (free text)
+  COMPREPLY=()
+}
+
+_git_amend_all() {
+  COMPREPLY=()
+}
+
+_git_attic() {
+  COMPREPLY=()
+}
+
+_git_authors() {
+  __git_extra_complete_words "$(git ls-files 2>/dev/null)"
+}
+
+_git_big_file() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) COMPREPLY=($(compgen -W "$(__git_extra_refs)" -- "$cur")) ;;
+    2) COMPREPLY=() ;; # threshold in MB, free text
+  esac
+}
+
+_git_branch_clean() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_branch_date() {
+  COMPREPLY=()
+}
+
+_git_branch_diff() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_branch_name() {
+  COMPREPLY=()
+}
+
+_git_branch_rebaser() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_branch_status() {
+  COMPREPLY=()
+}
+
+_git_branches() {
+  COMPREPLY=()
+}
+
+_git_branches_that_touch() {
+  COMPREPLY=($(compgen -d -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_brcl() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_bug_clusters() {
+  COMPREPLY=()
+}
+
+_git_capture_wip() {
+  COMPREPLY=()
+}
+
+_git_change_author() {
+  # args: old-author new-name new-email (all free text)
+  COMPREPLY=()
+}
+
+_git_changelog() {
+  COMPREPLY=()
+}
+
+_git_changes() {
+  __git_extra_complete_words "$(git ls-files 2>/dev/null)"
+}
+
+_git_checkout_branches() {
+  COMPREPLY=()
+}
+
+_git_checkout_by_date() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -ge 2 ]]; then
+    COMPREPLY=($(compgen -W "$(__git_extra_tracked_files)" -- "$cur"))
+  fi
+}
+
+_git_checkout_commit() {
+  COMPREPLY=()
+}
+
+_git_checkout_default_branch() {
+  COMPREPLY=()
+}
+
+_git_checkout_latest_tag() {
+  COMPREPLY=()
+}
+
+_git_checkout_pr() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "clean" ;;
+    2) __git_extra_complete_words "$(__git_extra_remote_names)" ;;
+  esac
+}
+
+_git_checkout_preview() {
+  COMPREPLY=()
+}
+
+_git_checkout_tag() {
+  __git_extra_complete_words "$(__git_extra_tag_names)"
+}
+
+_git_children_of() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_churn() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "--since= --until= --after= --before=" -- "$cur"))
+}
+
+_git_clone_subset() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "-h --help"
+       COMPREPLY+=($(compgen -d -- "$cur")) ;;
+    2) COMPREPLY=($(compgen -d -- "$cur")) ;;
+    3) COMPREPLY=() ;; # file pattern, free text
+  esac
+}
+
+_git_comma() {
+  COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_commit_browser() {
+  COMPREPLY=()
+}
+
+_git_commit_count() {
+  COMPREPLY=()
+}
+
+_git_commits_per_day() {
+  COMPREPLY=()
+}
+
+_git_compact() {
+  COMPREPLY=()
+}
+
+_git_conflicts() {
+  COMPREPLY=()
+}
+
+_git_copy_branch_name() {
+  COMPREPLY=()
+}
+
+_git_credit() {
+  # args: author-name author-email (free text)
+  COMPREPLY=()
+}
+
+_git_credit_author() {
+  COMPREPLY=()
+}
+
+_git_current_branch() {
+  COMPREPLY=()
+}
+
+_git_current_commit() {
+  COMPREPLY=()
+}
+
+_git_cut_branch() {
+  # arg: new branch name (free text)
+  COMPREPLY=()
+}
+
+_git_delete_dangling_commits() {
+  COMPREPLY=()
+}
+
+_git_delete_local_merged() {
+  COMPREPLY=()
+}
+
+_git_delete_merged_branches() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_delete_remote_branch() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "$(__git_extra_remote_names)" ;;
+    2) __git_extra_complete_words "$(__git_extra_remote_branch_names)" ;;
+  esac
+}
+
+_git_delete_squashed_and_merged_branches() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_delete_tag() {
+  __git_extra_complete_words "$(__git_extra_tag_names)"
+}
+
+_git_diff_last() {
+  __git_extra_complete_words "$(__git_extra_tracked_files)"
+}
+
+_git_divergence() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "$(__git_extra_branch_names)" ;;
+    2) __git_extra_complete_words "$(__git_extra_remote_branch_names)" ;;
+  esac
+}
+
+_git_edit_conflicts() {
+  COMPREPLY=()
+}
+
+_git_fetch_prs() {
+  __git_extra_complete_words "$(__git_extra_remote_names)"
+}
+
+_git_files() {
+  COMPREPLY=()
+}
+
+_git_find_dirty() {
+  COMPREPLY=($(compgen -d -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_firefights() {
+  COMPREPLY=()
+}
+
+_git_flush() {
+  COMPREPLY=()
+}
+
+_git_force_mtimes() {
+  COMPREPLY=()
+}
+
+_git_forest() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "--all --no-color --no-rebase -a --reverse --sha --style= --svdepth= --pretty="
+}
+
+_git_functionlog() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -ge 2 ]]; then
+    COMPREPLY=($(compgen -W "$(__git_extra_tracked_files)" -- "$cur"))
+  fi
+}
+
+_git_fzf_add() {
+  COMPREPLY=()
+}
+
+_git_fzf_log_browser() {
+  COMPREPLY=()
+}
+
+_git_fzf_pickaxe_browser() {
+  # arg: search term (free text)
+  COMPREPLY=()
+}
+
+_git_fzf_reflog_browser() {
+  COMPREPLY=()
+}
+
+_git_git() {
+  COMPREPLY=()
+}
+
+_git_github_open() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=($(compgen -W "$(__git_extra_tracked_files)" -- "$cur"))
+  fi
+}
+
+_git_gitlab_mr() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_history_eraser() {
+  COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_history_graph() {
+  COMPREPLY=()
+}
+
+_git_ignored() {
+  COMPREPLY=()
+}
+
+_git_improved_merge() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_incoming() {
+  __git_extra_complete_words "$(__git_extra_remote_branch_names)"
+}
+
+_git_jump() {
+  __git_extra_complete_words "forward backward"
+}
+
+_git_latest_tag() {
+  COMPREPLY=()
+}
+
+_git_lines() {
+  # arg: file extension (free text)
+  COMPREPLY=()
+}
+
+_git_list_semvers() {
+  COMPREPLY=()
+}
+
+_git_log_single_file() {
+  __git_extra_complete_words "$(__git_extra_tracked_files)"
+}
+
+_git_ls_branch_files() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_ls_conflicts() {
+  COMPREPLY=()
+}
+
+_git_ls_object_refs() {
+  # arg: object SHA1 (free text)
+  COMPREPLY=()
+}
+
+_git_make_gitignore() {
+  # arg: language/framework names (free text)
+  COMPREPLY=()
+}
+
+_git_mark_all_resolved() {
+  COMPREPLY=()
+}
+
+_git_maxpack() {
+  COMPREPLY=()
+}
+
+_git_merged_branches() {
+  COMPREPLY=()
+}
+
+_git_most_changed() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "-h --help -n --num-files --numfiles"
+}
+
+_git_mostchanged() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "-h --help -n --num-files --numfiles"
+}
+
+_git_move_commits() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -eq 2 ]]; then
+    COMPREPLY=($(compgen -W "$(__git_extra_branch_names)" -- "$cur"))
+  fi
+}
+
+_git_neck() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_nuke() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_nuke_untracked_files() {
+  COMPREPLY=()
+}
+
+_git_object_deflate() {
+  COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_oldest_common_ancestor() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_open_jira() {
+  COMPREPLY=()
+}
+
+_git_origin_head() {
+  COMPREPLY=()
+}
+
+_git_outgoing() {
+  __git_extra_complete_words "$(__git_extra_remote_branch_names)"
+}
+
+_git_overwritten() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_pie_ify() {
+  # args: pattern replacement (free text)
+  COMPREPLY=()
+}
+
+_git_plotrepo() {
+  COMPREPLY=()
+}
+
+_git_pr_fetch() {
+  __git_extra_complete_words "$(__git_extra_remote_names)"
+}
+
+_git_pr_list() {
+  COMPREPLY=()
+}
+
+_git_promote() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "$(__git_extra_remote_names)" ;;
+    2) __git_extra_complete_words "$(__git_extra_branch_names)" ;;
+  esac
+}
+
+_git_prune_branches() {
+  COMPREPLY=()
+}
+
+_git_pruneall() {
+  __git_extra_complete_words "$(__git_extra_remote_names)"
+}
+
+_git_publish() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "$(__git_extra_remote_names)" ;;
+    2) __git_extra_complete_words "$(__git_extra_branch_names)" ;;
+  esac
+}
+
+_git_purge_from_history() {
+  COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_pylint() {
+  COMPREPLY=()
+}
+
+_git_rank_contributors() {
+  __git_extra_complete_words "-v -o"
+}
+
+_git_rebase_authors() {
+  COMPREPLY=()
+}
+
+_git_rebase_theirs() {
+  __git_extra_complete_words "$(__git_extra_conflicted_files)"
+}
+
+_git_rebase_work_in_progress() {
+  COMPREPLY=()
+}
+
+_git_recent() {
+  COMPREPLY=()
+}
+
+_git_recently_checkedout_branches() {
+  COMPREPLY=()
+}
+
+_git_ref_recent() {
+  COMPREPLY=()
+}
+
+_git_rel() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_related() {
+  __git_extra_complete_words "$(__git_extra_tracked_files)"
+}
+
+_git_release_tag() {
+  __git_extra_complete_words "$(__git_extra_tag_names)"
+}
+
+_git_remote_default_branch() {
+  __git_extra_complete_words "$(__git_extra_remote_names)"
+}
+
+_git_remove_conflicts() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "ours theirs" ;;
+    *) __git_extra_complete_words "$(__git_extra_conflicted_files)" ;;
+  esac
+}
+
+_git_rename_branches() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "-h --help -v --verbose -n --dry-run"
+}
+
+_git_replace_author() {
+  # args: old-name new-name new-email (free text)
+  COMPREPLY=()
+}
+
+_git_reset_with_fire() {
+  COMPREPLY=()
+}
+
+_git_restore_mtime() {
+  __git_extra_complete_words "$(__git_extra_tracked_files)"
+}
+
+_git_review_commits() {
+  COMPREPLY=()
+}
+
+_git_rm_deleted_from_repo() {
+  COMPREPLY=()
+}
+
+_git_root_directory() {
+  COMPREPLY=()
+}
+
+_git_roots() {
+  COMPREPLY=()
+}
+
+_git_run_command_on_revisions() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case $COMP_CWORD in
+    1) __git_extra_complete_words "-v $(__git_extra_refs)" ;;
+    2) __git_extra_complete_words "$(__git_extra_refs)" ;;
+    3) COMPREPLY=() ;; # command to run (free text)
+  esac
+}
+
+_git_semvers() {
+  COMPREPLY=()
+}
+
+_git_shamend() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "-h --help -a --all $(__git_extra_refs)"
+}
+
+_git_show_overwritten() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_shrink_repo() {
+  COMPREPLY=()
+}
+
+_git_side_by_side() {
+  __git_extra_complete_words "$(__git_extra_tracked_files)"
+}
+
+_git_sp() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    __git_extra_complete_words "-a"
+  fi
+}
+
+_git_sr() {
+  COMPREPLY=()
+}
+
+_git_stashes() {
+  COMPREPLY=()
+}
+
+_git_stats() {
+  COMPREPLY=()
+}
+
+_git_submodule_ls() {
+  COMPREPLY=()
+}
+
+_git_submodule_paths() {
+  COMPREPLY=()
+}
+
+_git_submodule_rm() {
+  COMPREPLY=($(compgen -d -- "${COMP_WORDS[COMP_CWORD]}"))
+}
+
+_git_superpull() {
+  COMPREPLY=()
+}
+
+_git_switch_branch() {
+  # arg: branch substring (free text, partial match)
+  COMPREPLY=()
+}
+
+_git_tag_and_sign() {
+  # args: tag-name tag-message (free text)
+  COMPREPLY=()
+}
+
+_git_tag_diff() {
+  COMPREPLY=()
+}
+
+_git_taglist() {
+  COMPREPLY=()
+}
+
+_git_tags() {
+  COMPREPLY=()
+}
+
+_git_thanks() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_track() {
+  COMPREPLY=()
+}
+
+_git_trail() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_undelete() {
+  # arg: file path (previously deleted, free text)
+  COMPREPLY=()
+}
+
+_git_undo() {
+  COMPREPLY=()
+}
+
+_git_undo_push() {
+  __git_extra_complete_words "$(__git_extra_branch_names)"
+}
+
+_git_unpushed() {
+  COMPREPLY=()
+}
+
+_git_unpushed_stat() {
+  COMPREPLY=()
+}
+
+_git_unreleased() {
+  COMPREPLY=()
+}
+
+_git_up() {
+  COMPREPLY=()
+}
+
+_git_up_old() {
+  COMPREPLY=()
+}
+
+_git_upstream_name() {
+  COMPREPLY=()
+}
+
+_git_upstream_sync() {
+  COMPREPLY=()
+}
+
+_git_velocity() {
+  COMPREPLY=()
+}
+
+_git_what_the_hell_just_happened() {
+  COMPREPLY=()
+}
+
+_git_when_merged() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_where() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_where_pr() {
+  __git_extra_complete_words "$(__git_extra_refs)"
+}
+
+_git_whoami() {
+  COMPREPLY=()
+}
+
+_git_winner() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "-h --help"
+}
+
+_git_wordiness() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __git_extra_complete_words "-h --help -help -csv --csv -tsv --tsv -nh -nohead --nohead --order= -s="
+}
+
+_git_wtf() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ "$cur" == -* ]]; then
+    __git_extra_complete_words "-l --long -a --all -A --all-commits -s --short -k --key -r --relations --dump-config"
+  else
+    __git_extra_complete_words "$(__git_extra_branch_names)"
+  fi
+}
+
+# --- Register completions ---
+# These work both as standalone commands (git-foo) and as git subcommands (git foo).
+# Git's completion framework calls _git_foo for "git foo" automatically if using
+# git-completion.bash; we register the standalone forms explicitly here.
+
+_git_extra_commands_list=(
+  git-add-match
+  git-add-username-remote
+  git-amend-all
+  git-attic
+  git-authors
+  git-big-file
+  git-branch-clean
+  git-branch-date
+  git-branch-diff
+  git-branch-name
+  git-branch-rebaser
+  git-branch-status
+  git-branches
+  git-branches-that-touch
+  git-brcl
+  git-bug-clusters
+  git-capture-wip
+  git-change-author
+  git-changelog
+  git-changes
+  git-checkout-branches
+  git-checkout-by-date
+  git-checkout-commit
+  git-checkout-default-branch
+  git-checkout-latest-tag
+  git-checkout-pr
+  git-checkout-preview
+  git-checkout-tag
+  git-children-of
+  git-churn
+  git-clone-subset
+  git-comma
+  git-commit-browser
+  git-commit-count
+  git-commits-per-day
+  git-compact
+  git-conflicts
+  git-copy-branch-name
+  git-credit
+  git-credit-author
+  git-current-branch
+  git-current-commit
+  git-cut-branch
+  git-delete-dangling-commits
+  git-delete-local-merged
+  git-delete-merged-branches
+  git-delete-remote-branch
+  git-delete-squashed-and-merged-branches
+  git-delete-tag
+  git-diff-last
+  git-divergence
+  git-edit-conflicts
+  git-fetch-prs
+  git-files
+  git-find-dirty
+  git-firefights
+  git-flush
+  git-force-mtimes
+  git-forest
+  git-functionlog
+  git-fzf-add
+  git-fzf-log-browser
+  git-fzf-pickaxe-browser
+  git-fzf-reflog-browser
+  git-git
+  git-github-open
+  git-gitlab-mr
+  git-history-eraser
+  git-history-graph
+  git-ignored
+  git-improved-merge
+  git-incoming
+  git-jump
+  git-latest-tag
+  git-lines
+  git-list-semvers
+  git-log-single-file
+  git-ls-branch-files
+  git-ls-conflicts
+  git-ls-object-refs
+  git-make-gitignore
+  git-mark-all-resolved
+  git-maxpack
+  git-merged-branches
+  git-most-changed
+  git-mostchanged
+  git-move-commits
+  git-neck
+  git-nuke
+  git-nuke-untracked-files
+  git-object-deflate
+  git-oldest-common-ancestor
+  git-open-jira
+  git-origin-head
+  git-outgoing
+  git-overwritten
+  git-pie-ify
+  git-plotrepo
+  git-pr-fetch
+  git-pr-list
+  git-promote
+  git-prune-branches
+  git-pruneall
+  git-publish
+  git-purge-from-history
+  git-pylint
+  git-rank-contributors
+  git-rebase-authors
+  git-rebase-theirs
+  git-rebase-work-in-progress
+  git-recent
+  git-recently-checkedout-branches
+  git-ref-recent
+  git-rel
+  git-related
+  git-release-tag
+  git-remote-default-branch
+  git-remove-conflicts
+  git-rename-branches
+  git-replace-author
+  git-reset-with-fire
+  git-restore-mtime
+  git-review-commits
+  git-rm-deleted-from-repo
+  git-root-directory
+  git-roots
+  git-run-command-on-revisions
+  git-semvers
+  git-shamend
+  git-show-overwritten
+  git-shrink-repo
+  git-side-by-side
+  git-sp
+  git-sr
+  git-stashes
+  git-stats
+  git-submodule-ls
+  git-submodule-paths
+  git-submodule-rm
+  git-superpull
+  git-switch-branch
+  git-tag-and-sign
+  git-tag-diff
+  git-taglist
+  git-tags
+  git-thanks
+  git-track
+  git-trail
+  git-undelete
+  git-undo
+  git-undo-push
+  git-unpushed
+  git-unpushed-stat
+  git-unreleased
+  git-up
+  git-up-old
+  git-upstream-name
+  git-upstream-sync
+  git-velocity
+  git-what-the-hell-just-happened
+  git-when-merged
+  git-where
+  git-where-pr
+  git-whoami
+  git-winner
+  git-wordiness
+  git-wtf
+)
+
+# Map command names (with hyphens) to function names (with underscores)
+for _cmd in "${_git_extra_commands_list[@]}"; do
+  _func="${_cmd//git-/git_}"
+  _func="_${_func//-/_}"
+  if declare -f "$_func" >/dev/null 2>&1; then
+    complete -F "$_func" "$_cmd"
+  fi
+done
+unset _cmd _func _git_extra_commands_list

--- a/git-extra-commands.plugin.zsh
+++ b/git-extra-commands.plugin.zsh
@@ -1,4 +1,4 @@
-# Copyright 2006-2023 Joseph Block <jpb@apesseekingknowledge.net>
+# Copyright 2006-2026 Joseph Block <jpb@apesseekingknowledge.net>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,71 +19,16 @@
 0="${${(M)0:#/*}:-$PWD/$0}"
 
 local git_extra_commands_bin="${0:h}/bin"
+local git_extra_commands_completions="${0:h}/completions"
 
 if [[ -z "${path[(r)${git_extra_commands_bin}]}" ]]; then
     path+=( "${git_extra_commands_bin}" )
 fi
 
+if [[ -z "${fpath[(r)${git_extra_commands_completions}]}" ]]; then
+    fpath=( "${git_extra_commands_completions}" ${fpath} )
+fi
+
 alias git-grab='git-incoming-commits'
 alias gitroot='cd $(git rev-parse --show-toplevel) && echo "$_"'
 alias git-cdroot='cd $(git rev-parse --show-toplevel) && echo "$_"'
-
-# Skipped:
-#   incoming-commits  (appears to be a dupe of grab)
-#   mark-all-resolved (git: 'conflicts' is not a git command.)
-zstyle ':completion:*:*:git:*' user-commands \
-  age:'A git-blame viewer, written using PyGTK written by Kristoffer Gronlund ' \
-  big-file:'List disk size of files in ref' \
-  branch-diff:'Diff between the default branch and a branch' \
-  branch-name:'Prints the current branch name to stdout for use in automation'\
-  change-author:'Rewrite commits, updating author/email' \
-  changes:'List authors/emails with commit count' \
-  checkout-tag:'Check out a git tag'\
-  churn:'List files in ref with change/commit count' \
-  copy-branch-name:'Copy the current branch name to the clipboard (pbcopy)' \
-  credit:'A very slightly quicker way to credit an author on the latest commit' \
-  current-branch:'Print the name of the current branch, helpful for automation' \
-  cut-branch:'Create a new named branch pointed at HEAD and reset the current branch to the head of its tracking branch' \
-  delete-local-merged:'Delete all local branches that have been merged into HEAD' \
-  divergence:'List local/remote (incoming/outgoing) changes for current branch' \
-  find-dirty:'Recurse current directory, listing "dirty" git clones' \
-  flush:'Recompactify your repo to be as small as possible' \
-  grab:'Add github remote, by username and repo' \
-  ignored:'List files currently being ignored by .gitignore' \
-  improved-merge:'Sophisticated git merge with integrated CI check and automatic cleanup upon completion' \
-  incoming:'Fetch remote tracking branch, and list incoming commits' \
-  ls-object-refs:'Find references to <object> SHA1 in refs, commits, and trees. All of them' \
-  maildiff: 'Simple git command to email diff in color to reviewer/co-worker & optionally attach patch file.' \
-  maxpack:'Repack with maximum compression' \
-  nuke:'Nukes a branch locally and on the origin remote' \
-  object-deflate:'Deflate an loose object file and write to standard output' \
-  outgoing:'Fetch remote tracking branch, and list outgoing commits' \
-  pie-ify:'Apply perl pie, on the fly' \
-  promote:'Promotes a local topic branch to a remote tracking branch of the same name, by pushing and then setting up the git config' \
-  pruneall:'Prune branches from specified remotes, or all remotes when <remote> not specified' \
-  prune-branches:'Simple script that cleans up unnecessary branches' \
-  publish:'Pushes/publishes current branch to specified remote' \
-  purge-from-history:'Script to permanently delete files/folders from your git repository' \
-  rank-contributors:"A simple script to trace through the logs and rank contributors by the total size of the diffs they're responsible for" \
-  rebase-authors:'Adds authorship info to interactive git rebase output' \
-  rel:'Shows the relationship between the current branch and <ref>' \
-  root-directory:"Print the root of the git checkout you're in" \
-  run-command-on-revisions:'Runs a given command over a range of Git revisions' \
-  shamend:'Amends your staged changes as a fixup to the specified older commit in the current branch' \
-  show-overwritten:"Aggregates git blame information about original owners of lines changed or removed in the '<base>...<head>' diff" \
-  sp:"'Simple push', commits and pushes. Use -a flag to add"\
-  submodule-rm:'Remove submodules from current repo' \
-  thanks:'List authors with commit count' \
-  track:'Sets up your branch to track a remote branch' \
-  trail:'Show all branching points in Git history' \
-  undo-push:'Undo your last push to branch ($1) of origin' \
-  unpushed:"Show the diff of everything you haven't pushed yet" \
-  unpushed-stat:"Show the diffstat of everything you haven't pushed yet" \
-  unreleased:'Shows git commits since the last tagged version' \
-  up-old:'Like git-pull but show a short and sexy log of changes immediately after merging (git-up) or rebasing (git-reup)' \
-  upstream-sync:'Sync to upstream/yourforkname and rebase into your local fork, then push' \
-  when-merged:'Find when a commit was merged into one or more branches' \
-  where:'Shows where a particular commit falls between releases' \
-  winner:'Determines "winner" by commit count, and number of lines' \
-  wordiness:'List commit message word and line counts per contributor' \
-  wtf:'Displays the state of your repository in a readable, easy-to-scan format'


### PR DESCRIPTION
## Add shell completions for all bin scripts (zsh + bash)

### Summary

Adds comprehensive tab completion support for all 145 scripts in
`bin/`, covering both ZSH and Bash. Previously, only ~40 commands had
ZSH subcommand descriptions and none had argument-level completions.

### Changes

**New files:**

- `completions/_git-extra-commands` — Zsh completions providing:
  - `zstyle` subcommand descriptions for `git <TAB>` (all 145 commands)
  - `_git-<command>` functions with argument/flag completions (branch
    names, remotes, tags, tracked files, flags like `--dry-run`, enum
    values like `ours|theirs`, etc.)

- `completions/git-extra-commands.bash` — Bash completions providing:
  - Equivalent argument completions via `complete -F` for all commands
  - Positional argument awareness and flag completion
  - Helper functions for dynamic completion of branches, remotes, tags,
    tracked files, and conflicted files

**Modified files:**

- `git-extra-commands.plugin.zsh`:
  - Adds `completions/` to `fpath` so zsh discovers the completion
    functions automatically
  - Removes the old inline `zstyle` block (moved to completions file
    where it belongs)
  - Plugin file is now lean: just `PATH`/`fpath` setup and aliases

### Highlights

- Every non-symlink script has a completion function
- Symlink aliases (e.g. `git-changes`, `git-current-branch`) are also
  completable
- Commands with CLI flags get proper flag completion:
  `git-shamend -a/--all/-h/--help`,
  `git-rename-branches -v/-n/--dry-run`,
  `git-mostchanged -n/--num-files`,
  `git-wtf -l/-a/-A/-s/-k/-r/--dump-config`,
  `git-wordiness -csv/-tsv/--order=`,
  `git-forest --all/--style=/--sha`
- Commands that take branches, tags, remotes, or files complete from
  live repository state
- Commands with positional semantics complete the correct type per
  position (e.g. `git-delete-remote-branch <remote> <branch>`)

### Testing

- `zsh -n` syntax check passes on both zsh files
- `bash -n` syntax check passes on the bash file
- Sourcing the zsh file defines 167 `_git-*` functions
- Sourcing the bash file registers 167 `complete -F` entries
- Spot-tested argument completion for `git-shamend`, `git-nuke`,
  `git-wtf`, `git-mostchanged`, `git-clone-subset`,
  `git-rename-branches`, `git-delete-remote-branch`

### Usage

**Zsh** — works automatically when loaded as a plugin (zgenom, antigen,
oh-my-zsh, etc.). The plugin adds `completions/` to `fpath`.

**Bash** — source the file in `.bashrc` or drop it in a completions
directory:

```bash
source /path/to/git-extra-commands/completions/git-extra-commands.bash
```

### Breaking changes

- The `zstyle` block is no longer in git-extra-commands.plugin.zsh. Users who were sourcing only that file and relying on completions now need the completions/ directory in their fpath (which the plugin handles automatically). Anyone loading this as a proper ZSH plugin is unaffected.
- Removed completion entries for commands that don't exist in bin/: age, grab, maildiff.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [x] Add/Remove/Update a helper script or `git` alias
- [ ] Add/Remove/Update link to an external resource like a blog post or video
- [x] Plugin file updates - functions added here probably should be standalone scripts in `/bin`
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have confirmed that the link(s) in my PR are valid.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
