### PR TITLE
Allowlist archive.* sites

### DIFF
--- a/.github/workflows/awesomebot.yml
+++ b/.github/workflows/awesomebot.yml
@@ -20,4 +20,4 @@ jobs:
         fetch-depth: 0
     - uses: docker://dkhamsing/awesome_bot:latest
       with:
-        args: /github/workspace/README.md --allow-ssl --allow 202,403,429,500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io,https://twitter.com,https://medium.com,https://stackoverflow.com,https://contributors-img.web.app,https://github.com/unixorn/git-extra-commands/stargazers
+        args: /github/workspace/README.md --allow-ssl --allow 202,403,429,500,501,502,503,504,509,521 --allow-dupe --allow-redirect --request-delay 1 --white-list https://github,https://img.shields.io,https://twitter.com,https://medium.com,https://stackoverflow.com,https://contributors-img.web.app,https://github.com/unixorn/git-extra-commands/stargazers,https://archive.today,https://archive.ph,https://archive.is


### PR DESCRIPTION
# Description

The various archive sites sometimes are slammed and awesomebot fails to establish a tcp connection.

Whitelisting the ones I remember off the top of my head

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] Add/Remove/Update a helper script or `git` alias
- [ ] Add/Remove/Update link to an external resource like a blog post or video
- [ ] Plugin file updates - functions added here probably should be standalone scripts in `/bin`
- [ ] Text cleanups/updates
- [x] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have confirmed that the link(s) in my PR are valid.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [ ] Scripts added/updated in this PR are all marked executable.
- [ ] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have added a credit line to [README.md](https://github.com/unixorn/git-extra-commands/blob/main/README.md) for any new scripts.
- [ ] If there was no author credit inside a script added in this PR, I have added one.
