### PR TITLE
Fix `gh` availability check in git-pr-list

### DIFF
--- a/bin/git-pr-list
+++ b/bin/git-pr-list
@@ -27,7 +27,7 @@ function has() {
 
 myname=$(basename "$0")
 
-if ! has ghx; then
+if ! has gh; then
   msg="$myname requires that gh be installed."
   if [[ "$(uname -s)" = "Darwin" ]]; then
     msg="$msg  Try 'brew install gh' or check the install instructions at https://github.com/cli/cli"


### PR DESCRIPTION
`git-pr-list` guards on a command named `ghx`:

```bash
if ! has ghx; then
  msg="$myname requires that gh be installed."
```

Nothing provides that name, so the check fails on every machine and the script exits before it reaches the `gh api` call on the last line — `git-pr-list` has never worked.

The typo is masked by its own error message: it says "requires that gh be installed" and suggests `brew install gh`, so users install `gh`, hit the identical error, and move on without reading the source. It's been there since the script was added in 066e289.

This changes the guard to check `gh`, which is what the script actually invokes. Nothing else in the file references `ghx`.

After the fix, on this repo:

```
$ bin/git-pr-list
1236    dependabot[bot] Bump charset-normalizer from 3.4.9 to 3.5.1
1234    dependabot[bot] Bump pygithub from 2.9.1 to 2.10.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)